### PR TITLE
modularise utils package

### DIFF
--- a/pkg/install/endpoints.go
+++ b/pkg/install/endpoints.go
@@ -87,7 +87,9 @@ func validateEndpoints(endpoints, etcdShell string) error {
 		return err
 	}
 
-	err = pluginutils.PodIsRunning(config, etcdShellPodName, etcdShellPodNS, 60, 5)
+	err = pluginutils.WaitFor(func() error {
+		return pluginutils.PodIsRunning(config, etcdShellPodName, etcdShellPodNS)
+	}, 60, 5)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -1,0 +1,171 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	storagev1 "k8s.io/client-go/kubernetes/typed/storage/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// NewClientConfig returns a client-go rest config
+func NewClientConfig() (*rest.Config, error) {
+	configFlags := &genericclioptions.ConfigFlags{}
+
+	config, err := configFlags.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+// GetClientsetFromConfig returns a k8s clientset from a client-go rest config
+func GetClientsetFromConfig(config *rest.Config) (*kubernetes.Clientset, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset, nil
+}
+
+// ExecToPod execs into a pod and executes command from inside that pod.
+// containerName can be "" if the pod contains only a single container.
+// Returned are strings represent STDOUT and STDERR respectively.
+// Also returned is any error encountered.
+func ExecToPod(config *rest.Config, command []string, containerName, podName, namespace string, stdin io.Reader) (string, string, error) {
+	clientset, err := GetClientsetFromConfig(config)
+	if err != nil {
+		return "", "", err
+	}
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec")
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return "", "", fmt.Errorf("error adding to scheme: %v", err)
+	}
+
+	parameterCodec := runtime.NewParameterCodec(scheme)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Command:   command,
+		Container: containerName,
+		Stdin:     stdin != nil,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, parameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", "", fmt.Errorf("error while creating Executor: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("error in Stream: %v", err)
+	}
+
+	return stdout.String(), stderr.String(), nil
+}
+
+// GetDefaultStorageClassName returns the name of the default storage class in the cluster, if more
+// than one storage class is set to default, the first one discovered is returned. An error is returned
+// if no default storage class is found.
+func GetDefaultStorageClassName() (string, error) {
+	restConfig, err := NewClientConfig()
+	if err != nil {
+		return "", err
+	}
+
+	storageV1Client, err := storagev1.NewForConfig(restConfig)
+	if err != nil {
+		return "", err
+	}
+	storageClasses, err := storageV1Client.StorageClasses().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, storageClass := range storageClasses.Items {
+		for k, v := range storageClass.GetObjectMeta().GetAnnotations() {
+			if k == "storageclass.kubernetes.io/is-default-class" && v == "true" {
+				return storageClass.GetObjectMeta().GetName(), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no default storage class discovered in cluster")
+}
+
+// WaitFor runs 'fn' every 'interval' for duration of 'limit', returning no error only if 'fn' returns no
+// error inside 'limit'
+func WaitFor(fn func() error, limit, interval time.Duration) error {
+	timeout := time.After(time.Second * limit)
+	ticker := time.NewTicker(time.Second * interval)
+	defer ticker.Stop()
+	var err error
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout with error: %v", err)
+		case <-ticker.C:
+			err = fn()
+			if err == nil {
+				return nil
+			}
+		}
+	}
+}
+
+// DeploymentIsReady attempts to `get` a deployment by name and namespace, the function returns no error
+// if no deployment replicas are ready.
+func DeploymentIsReady(config *rest.Config, name, namespace string) error {
+	clientset, err := GetClientsetFromConfig(config)
+	if err != nil {
+		return err
+	}
+	depClient := clientset.AppsV1().Deployments(namespace)
+
+	dep, err := depClient.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if dep.Status.ReadyReplicas == 0 {
+		return fmt.Errorf("no replicas are ready for deployment %s; %s", name, namespace)
+	}
+	return nil
+}
+
+// PodIsRunning attempts to `get` a pod by name and namespace, the function returns no error
+// if the pod is in running phase.
+func PodIsRunning(config *rest.Config, name, namespace string) error {
+	clientset, err := GetClientsetFromConfig(config)
+	if err != nil {
+		return err
+	}
+	podClient := clientset.CoreV1().Pods(namespace)
+	pod, err := podClient.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if pod.Status.Phase != corev1.PodRunning {
+		return fmt.Errorf("pod %s; %s is not in running phase", name, namespace)
+	}
+	return nil
+}

--- a/pkg/utils/yaml.go
+++ b/pkg/utils/yaml.go
@@ -1,129 +1,21 @@
-package install
+package utils
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
-	"golang.org/x/sync/errgroup"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/kubernetes"
-	storagev1 "k8s.io/client-go/kubernetes/typed/storage/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
-// NewClientConfig returns a client-go rest config
-func NewClientConfig() (*rest.Config, error) {
-	configFlags := &genericclioptions.ConfigFlags{}
-
-	config, err := configFlags.ToRESTConfig()
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-// GetClientsetFromConfig returns a k8s clientset from a client-go rest config
-func GetClientsetFromConfig(config *rest.Config) (*kubernetes.Clientset, error) {
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return clientset, nil
-}
-
-// ExecToPod execs into a pod and executes command from inside that pod.
-// containerName can be "" if the pod contains only a single container.
-// Returned are strings represent STDOUT and STDERR respectively.
-// Also returned is any error encountered.
-func ExecToPod(config *rest.Config, command []string, containerName, podName, namespace string, stdin io.Reader) (string, string, error) {
-	clientset, err := GetClientsetFromConfig(config)
-	if err != nil {
-		return "", "", err
-	}
-	req := clientset.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(podName).
-		Namespace(namespace).
-		SubResource("exec")
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		return "", "", fmt.Errorf("error adding to scheme: %v", err)
-	}
-
-	parameterCodec := runtime.NewParameterCodec(scheme)
-	req.VersionedParams(&corev1.PodExecOptions{
-		Command:   command,
-		Container: containerName,
-		Stdin:     stdin != nil,
-		Stdout:    true,
-		Stderr:    true,
-		TTY:       false,
-	}, parameterCodec)
-
-	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
-	if err != nil {
-		return "", "", fmt.Errorf("error while creating Executor: %v", err)
-	}
-
-	var stdout, stderr bytes.Buffer
-	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:  stdin,
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Tty:    false,
-	})
-	if err != nil {
-		return "", "", fmt.Errorf("error in Stream: %v", err)
-	}
-
-	return stdout.String(), stderr.String(), nil
-}
-
-// GetDefaultStorageClassName returns the name of the default storage class in the cluster, if more
-// than one storage class is set to default, the first one discovered is returned. An error is returned
-// if no default storage class is found.
-func GetDefaultStorageClassName() (string, error) {
-	restConfig, err := NewClientConfig()
-	if err != nil {
-		return "", err
-	}
-
-	storageV1Client, err := storagev1.NewForConfig(restConfig)
-	if err != nil {
-		return "", err
-	}
-	storageClasses, err := storageV1Client.StorageClasses().List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return "", err
-	}
-	for _, storageClass := range storageClasses.Items {
-		for k, v := range storageClass.GetObjectMeta().GetAnnotations() {
-			if k == "storageclass.kubernetes.io/is-default-class" && v == "true" {
-				return storageClass.GetObjectMeta().GetName(), nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("no default storage class discovered in cluster")
-}
-
 // GetManifestFromMultiDoc returns an individual object string from a multi-doc yaml file
 // after searching by kind. Note: the first object in multiManifest matching kind is returned.
-func GetManifestFromMultiDoc(multiManifest, kind string) (string, error) {
-	objs, err := manifest.ParseObjects(context.TODO(), multiManifest)
+func GetManifestFromMultiDoc(multiDoc, kind string) (string, error) {
+	objs, err := manifest.ParseObjects(context.TODO(), multiDoc)
 	if err != nil {
 		return "", err
 	}
@@ -137,6 +29,26 @@ func GetManifestFromMultiDoc(multiManifest, kind string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no object of kind: %s found in multi doc manifest", kind)
+}
+
+// GetAllManifestsOfKindFromMultiDoc returns a slice of strings from a multi-doc yaml file
+// after searching by kind. Each string represents a sinlge manifest of 'kind'.
+func GetAllManifestsOfKindFromMultiDoc(multiDoc, kind string) ([]string, error) {
+	objs, err := manifest.ParseObjects(context.TODO(), multiDoc)
+	if err != nil {
+		return nil, err
+	}
+	objsOfKind := make([]string, 0)
+	for _, obj := range objs.Items {
+		if obj.UnstructuredObject().GetKind() == kind {
+			objYaml, err := yaml.Marshal(obj.UnstructuredObject())
+			if err != nil {
+				return nil, err
+			}
+			objsOfKind = append(objsOfKind, string(objYaml))
+		}
+	}
+	return objsOfKind, nil
 }
 
 // SetFieldInManifest sets valueName equal to value at path in manifest defined by fields.
@@ -476,68 +388,4 @@ kind: Namespace
 metadata:
   name: `, namespace)
 
-}
-
-// PodIsRunning attempts to `get` a pod by name and namespace, the function returns no error
-// if the pod is in running phase. If an error occurs during `get`, the error is returned.
-// If the pod is a phase other than running, `get` is executed again after `interval` seconds.
-// After `limit` seconds, the function times out and returns timeout error.
-func PodIsRunning(config *rest.Config, name, namespace string, limit, interval time.Duration) error {
-	clientset, err := GetClientsetFromConfig(config)
-	if err != nil {
-		return err
-	}
-	podClient := clientset.CoreV1().Pods(namespace)
-	timeout := time.After(time.Second * limit)
-	errs, ctx := errgroup.WithContext(context.TODO())
-	errs.Go(func() error {
-		for {
-			select {
-			case <-timeout:
-				return fmt.Errorf("timeout attempting to reach pod %s;%s", name, namespace)
-			default:
-				pod, err := podClient.Get(ctx, name, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				if pod.Status.Phase == corev1.PodRunning {
-					return nil
-				}
-				time.Sleep(interval * time.Second)
-			}
-		}
-	})
-	return errs.Wait()
-}
-
-// DeploymentIsReady attempts to `get` a deployment by name and namespace, the function returns no error
-// if the deployment replicas are all ready. If an error occurs during `get`, the error is returned.
-// If the deployment replicas are not all ready, `get` is executed again after `interval` seconds.
-// After `limit` seconds, the function times out and returns timeout error.
-func DeploymentIsReady(config *rest.Config, name, namespace string, limit, interval time.Duration) error {
-	clientset, err := GetClientsetFromConfig(config)
-	if err != nil {
-		return err
-	}
-	depClient := clientset.AppsV1().Deployments(namespace)
-	timeout := time.After(time.Second * limit)
-	errs, ctx := errgroup.WithContext(context.TODO())
-	errs.Go(func() error {
-		for {
-			select {
-			case <-timeout:
-				return fmt.Errorf("timeout attempting to reach deployment %s;%s", name, namespace)
-			default:
-				dep, err := depClient.Get(ctx, name, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				if *dep.Spec.Replicas == dep.Status.ReadyReplicas {
-					return nil
-				}
-				time.Sleep(interval * time.Second)
-			}
-		}
-	})
-	return errs.Wait()
 }


### PR DESCRIPTION
Really just some code tidy up, but will also be useful for ongoing work on `uninstall` and `upgrade` command

* Split `utils.go` into separate files for k8s and yaml
* Reduce code duplication and provide more generic functions for checking k8s object readiness 
* Replace `sleep` after ETCD operator creation with legitimate check before proceeding 