### PR TITLE
Write uninstalled manifests to disk

### DIFF
--- a/.github/workflows/kuttl-e2e-test.yaml
+++ b/.github/workflows/kuttl-e2e-test.yaml
@@ -23,4 +23,4 @@ jobs:
           make _build-pre
           sudo cp bin/kubectl-storageos $KUBECTL_STORAGEOS      
       - name: Run kuttl
-        run: kubectl-kuttl test --config tests/e2e/kuttl-test.yaml
+        run: sudo kubectl-kuttl test --config tests/e2e/kuttl-test.yaml

--- a/cmd/plugin/cli/uninstall.go
+++ b/cmd/plugin/cli/uninstall.go
@@ -68,7 +68,7 @@ func uninstallCmd(cmd *cobra.Command) error {
 		return err
 	}
 
-	err = cliInstaller.Uninstall(ksConfig)
+	err = cliInstaller.Uninstall(ksConfig, false)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/fatih/color v1.7.0
 	github.com/frankban/quicktest v1.13.0 // indirect
+	github.com/ghodss/yaml v1.0.0
+	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/hashicorp/go-version v1.1.0
 	github.com/improbable-eng/etcd-cluster-operator v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ github.com/go-toolsmith/pkgload v0.0.0-20181119091011-e9e65178eee8/go.mod h1:WoM
 github.com/go-toolsmith/pkgload v1.0.0/go.mod h1:5eFArkbO80v7Z0kdngIxsRXRMTaX4Ilcwuh3clNrQJc=
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
+github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
+github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -2,7 +2,6 @@ package installer
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"path/filepath"
 
@@ -145,7 +144,7 @@ func (in *Installer) installStorageOS(config *apiv1.KubectlStorageOSConfig) erro
 		usernamePatch := pluginutils.KustomizePatch{
 			Op:    "replace",
 			Path:  "/data/username",
-			Value: base64.StdEncoding.EncodeToString([]byte(config.InstallerMeta.SecretUsername)),
+			Value: config.InstallerMeta.SecretUsername,
 		}
 
 		err := in.addPatchesToFSKustomize(filepath.Join(stosDir, clusterDir, kustomizationFile), "Secret", fsSecretName, []pluginutils.KustomizePatch{usernamePatch})
@@ -159,7 +158,7 @@ func (in *Installer) installStorageOS(config *apiv1.KubectlStorageOSConfig) erro
 		passwordPatch := pluginutils.KustomizePatch{
 			Op:    "replace",
 			Path:  "/data/password",
-			Value: base64.StdEncoding.EncodeToString([]byte(config.InstallerMeta.SecretPassword)),
+			Value: config.InstallerMeta.SecretPassword,
 		}
 
 		err := in.addPatchesToFSKustomize(filepath.Join(stosDir, clusterDir, kustomizationFile), "Secret", fsSecretName, []pluginutils.KustomizePatch{passwordPatch})

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -1,10 +1,19 @@
 package installer
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	otkkubectl "github.com/darkowlzz/operator-toolkit/declarative/kubectl"
+	operatorapi "github.com/storageos/cluster-operator/pkg/apis/storageos/v1"
 	apiv1 "github.com/storageos/kubectl-storageos/api/v1"
 	pluginutils "github.com/storageos/kubectl-storageos/pkg/utils"
 
+	corev1 "k8s.io/api/core/v1"
+	kstoragev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/kustomize/api/filesys"
 )
@@ -45,15 +54,20 @@ const (
 	UninstallSkipEtcdConfig       = "spec.uninstall.skipEtcd"
 
 	// dir and file names for in memory fs
-	etcdDir           = "etcd"
-	stosDir           = "storageos"
-	operatorDir       = "operator"
-	clusterDir        = "cluster"
-	stosOperatorFile  = "storageos-operator.yaml"
-	stosClusterFile   = "storageos-cluster.yaml"
-	etcdOperatorFile  = "etcd-operator.yaml"
-	etcdClusterFile   = "etcd-cluster.yaml"
-	kustomizationFile = "kustomization.yaml"
+	etcdDir              = "etcd"
+	stosDir              = "storageos"
+	operatorDir          = "operator"
+	clusterDir           = "cluster"
+	stosOperatorFile     = "storageos-operator.yaml"
+	stosClusterFile      = "storageos-cluster.yaml"
+	stosSecretsFile      = "storageos-secrets.yaml"
+	csiSecretsFile       = "storageos-csi-secrets.yaml"
+	stosStorageClassFile = "storageos-storageclass.yaml"
+	etcdOperatorFile     = "etcd-operator.yaml"
+	etcdClusterFile      = "etcd-cluster.yaml"
+	kustomizationFile    = "kustomization.yaml"
+	kubeDir              = ".kube"
+	uninstallDirPrefix   = "uninstall-"
 
 	// kustomization template
 	kustTemp = `apiVersion: kustomize.config.k8s.io/v1beta1
@@ -61,11 +75,14 @@ kind: Kustomization
 
 resources:`
 
+	// other defaults
 	stosClusterKind        = "StorageOSCluster"
 	etcdClusterKind        = "EtcdCluster"
 	defaultEtcdClusterName = "storageos-etcd"
 	defaultEtcdClusterNS   = "storageos-etcd"
 	stosFinalizer          = "storageos.com/finalizer"
+	stosSCProvisioner      = "csi.storageos.com"
+	stosAppLabel           = "app=storageos"
 )
 
 // fsData represents dir name, subdir name, file name and file data.
@@ -76,7 +93,9 @@ type fsData map[string]map[string]map[string][]byte
 type Installer struct {
 	kubectlClient *otkkubectl.DefaultKubectl
 	clientConfig  *rest.Config
+	kubeClusterID types.UID
 	fileSys       filesys.FileSystem
+	onDiskFileSys filesys.FileSystem
 }
 
 // NewInstaller returns an Installer object with the kubectl client and in-memory filesystem
@@ -95,6 +114,11 @@ func NewInstaller(config *apiv1.KubectlStorageOSConfig, ensureNamespace bool) (*
 		}
 	}
 
+	kubesystemNS, err := pluginutils.GetNamespace(clientConfig, "kube-system")
+	if err != nil {
+		return installer, err
+	}
+
 	fileSys, err := buildInstallerFileSys(config, clientConfig)
 	if err != nil {
 		return installer, err
@@ -103,7 +127,9 @@ func NewInstaller(config *apiv1.KubectlStorageOSConfig, ensureNamespace bool) (*
 	installer = &Installer{
 		kubectlClient: otkkubectl.New(),
 		clientConfig:  clientConfig,
+		kubeClusterID: kubesystemNS.GetUID(),
 		fileSys:       fileSys,
+		onDiskFileSys: filesys.MakeFsOnDisk(),
 	}
 
 	return installer, nil
@@ -176,14 +202,14 @@ func (in *Installer) getFieldInFsMultiDocByKind(path, kind string, fields ...str
 	return field, nil
 }
 
-// getManifestFromFsMultiDoc reads the file at path of the in-memory filesystem, uses
-// GetManifestFromMultiDoc internally to retrieve the individual manifest by kind.
-func (in *Installer) getManifestFromFsMultiDoc(path, kind string) (string, error) {
+// getManifestFromFsMultiDocByKind reads the file at path of the in-memory filesystem, uses
+// GetManifestFromMultiDocByKind internally to retrieve the individual manifest by kind.
+func (in *Installer) getManifestFromFsMultiDocByKind(path, kind string) (string, error) {
 	data, err := in.fileSys.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
-	singleManifest, err := pluginutils.GetManifestFromMultiDoc(string(data), kind)
+	singleManifest, err := pluginutils.GetManifestFromMultiDocByKind(string(data), kind)
 	if err != nil {
 		return "", err
 	}
@@ -221,4 +247,110 @@ func (in *Installer) omitAndReturnKindFromFSMultiDoc(path, kind string) ([]strin
 		return nil, err
 	}
 	return objsOfKind, nil
+}
+
+// writeBackupFileSystem writes manifests of uninstalled secrets, storageoscluster and storageclass to disk
+func (in *Installer) writeBackupFileSystem(storageOSCluster *operatorapi.StorageOSCluster) error {
+	backupPath, err := in.getBackupPath()
+	if err != nil {
+		return err
+	}
+	err = in.onDiskFileSys.MkdirAll(backupPath)
+	if err != nil {
+		return err
+	}
+
+	storageOSClusterManifest, err := storageOSClusterToManifest(storageOSCluster)
+	if err != nil {
+		return err
+	}
+	err = in.onDiskFileSys.WriteFile(filepath.Join(backupPath, stosClusterFile), storageOSClusterManifest)
+	if err != nil {
+		return err
+	}
+
+	secretList, err := pluginutils.ListSecrets(in.clientConfig, metav1.ListOptions{LabelSelector: stosAppLabel})
+	if err != nil {
+		return err
+	}
+	stosSecretList, csiSecretList := separateSecrets(secretList)
+	err = in.writeSecretsToDisk(stosSecretList, filepath.Join(backupPath, stosSecretsFile))
+	if err != nil {
+		return err
+	}
+	err = in.writeSecretsToDisk(csiSecretList, filepath.Join(backupPath, csiSecretsFile))
+	if err != nil {
+		return err
+	}
+
+	storageClassList, err := in.listStorageOSStorageClasses()
+	if err != nil {
+		return err
+	}
+	err = in.writeStorageClassesToDisk(storageClassList, filepath.Join(backupPath, stosStorageClassFile))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (in *Installer) listStorageOSStorageClasses() (*kstoragev1.StorageClassList, error) {
+	storageClassList, err := pluginutils.ListStorageClasses(in.clientConfig, metav1.ListOptions{LabelSelector: stosAppLabel})
+	if err != nil {
+		return nil, err
+	}
+	stosStorageClassList := &kstoragev1.StorageClassList{}
+	for _, storageClass := range storageClassList.Items {
+		if storageClass.Provisioner != stosSCProvisioner {
+			continue
+		}
+		stosStorageClassList.Items = append(stosStorageClassList.Items, storageClass)
+	}
+
+	return stosStorageClassList, nil
+
+}
+
+// writeSecretsToDisk writes multidoc manifest of SecretList.Items to path of on-disk filesystem
+func (in *Installer) writeSecretsToDisk(secretList *corev1.SecretList, path string) error {
+	if len(secretList.Items) == 0 {
+		return nil
+	}
+	secretsMultiDoc, err := secretsToMultiDoc(secretList)
+	if err != nil {
+		return err
+	}
+	err = in.onDiskFileSys.WriteFile(path, secretsMultiDoc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeStorageClassesToDisk writes multidoc manifest of StorageClassList.Items to path of on-disk filesystem
+func (in *Installer) writeStorageClassesToDisk(storageClassList *kstoragev1.StorageClassList, path string) error {
+	if len(storageClassList.Items) == 0 {
+		return nil
+	}
+	storageClassMultiDoc, err := storageClassesToMultiDoc(storageClassList)
+	if err != nil {
+		return err
+	}
+	err = in.onDiskFileSys.WriteFile(path, storageClassMultiDoc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// getBackupPath returns the path to the on-disk directory where uninstalled manifests are stored.
+func (in *Installer) getBackupPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, kubeDir, stosDir, fmt.Sprintf("%s%v", uninstallDirPrefix, in.kubeClusterID)), nil
 }

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -286,6 +286,20 @@ func GetStorageClass(config *rest.Config, name string) (*kstoragev1.StorageClass
 	return storageClass, nil
 }
 
+// ListStorageClasses returns StorageClassList
+func ListStorageClasses(config *rest.Config, listOptions metav1.ListOptions) (*kstoragev1.StorageClassList, error) {
+	clientset, err := GetClientsetFromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	storageClasses, err := clientset.StorageV1().StorageClasses().List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return storageClasses, nil
+}
+
 // CreateStorageClass creates k8s storage class.
 func CreateStorageClass(config *rest.Config, storageClass *kstoragev1.StorageClass) error {
 	clientset, err := GetClientsetFromConfig(config)
@@ -314,6 +328,20 @@ func GetSecret(config *rest.Config, name, namespace string) (*corev1.Secret, err
 	}
 
 	return secret, nil
+}
+
+// ListSecrets returns SecretList
+func ListSecrets(config *rest.Config, listOptions metav1.ListOptions) (*corev1.SecretList, error) {
+	clientset, err := GetClientsetFromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	secrets, err := clientset.CoreV1().Secrets("").List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return secrets, nil
 }
 
 // CreateSecret creates k8s secret.
@@ -355,10 +383,10 @@ func SecretExists(config *rest.Config, name, namespace string) error {
 // GetStorageOSCluster returns the storageoscluster object if it exists in the k8s cluster.
 // Use 'List' to discover as there can only be one object per k8s cluster and 'List' does not
 // require name/namespace - input namespace can optionally be passed to narrow the search.
-func GetStorageOSCluster(config *rest.Config, namespace string) (operatorapi.StorageOSCluster, error) {
+func GetStorageOSCluster(config *rest.Config, namespace string) (*operatorapi.StorageOSCluster, error) {
 	scheme := runtime.NewScheme()
 	operatorapi.AddToScheme(scheme)
-	stosCluster := operatorapi.StorageOSCluster{}
+	stosCluster := &operatorapi.StorageOSCluster{}
 
 	newClient, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
@@ -376,7 +404,7 @@ func GetStorageOSCluster(config *rest.Config, namespace string) (operatorapi.Sto
 		return stosCluster, kerrors.NewNotFound(operatorapi.SchemeGroupVersion.WithResource("StorageOSCluster").GroupResource(), "")
 	}
 
-	stosCluster = stosClusterList.Items[0]
+	stosCluster = &stosClusterList.Items[0]
 	return stosCluster, nil
 }
 

--- a/pkg/utils/yaml_test.go
+++ b/pkg/utils/yaml_test.go
@@ -18,6 +18,47 @@ func TestSetFieldInManifest(t *testing.T) {
 		expError    bool
 	}{
 		{
+			name: "set pod finalizer",
+			manifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-pod
+  namespace: default
+  labels:
+    app: java
+  annotations:
+    a.b.c: d.e.f
+spec:
+  templates:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+`,
+			value:     "- storageos",
+			valueName: "finalizers",
+			fields:    []string{"metadata"},
+			expManifest: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-pod
+  namespace: default
+  labels:
+    app: java
+  annotations:
+    a.b.c: d.e.f
+  finalizers:
+    - storageos
+spec:
+  templates:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest	
+`,
+		},
+
+		{
 			name: "set pod name",
 			manifest: `apiVersion: apps/v1
 kind: Deployment
@@ -316,7 +357,7 @@ patches:
 	}
 }
 
-func TestGetManifestFromMultiDoc(t *testing.T) {
+func TestGetManifestFromMultiDocByKind(t *testing.T) {
 	tcases := []struct {
 		name          string
 		multiManifest string
@@ -385,7 +426,7 @@ spec:
 		},
 	}
 	for _, tc := range tcases {
-		man, err := GetManifestFromMultiDoc(tc.multiManifest, tc.kind)
+		man, err := GetManifestFromMultiDocByKind(tc.multiManifest, tc.kind)
 		if err != nil {
 			if !tc.expError {
 				t.Errorf("unexpected error %v", err)


### PR DESCRIPTION
During uninstall phase write uninstalled secrets, storageclass and storageoscluster to disk:

-  `/root/.kube/storageos/uninstall-<kube-system-UUID>/`
    -  `storageos-cluster.yaml`  
    -  `storageos-secrets.yaml`
    -  `storageos-csi-secrets.yaml`
    -  `storageos-storageclass.yaml`