### PR TITLE
validate endpoints individually

### DIFF
--- a/pkg/installer/endpoints.go
+++ b/pkg/installer/endpoints.go
@@ -111,7 +111,11 @@ func validateEndpoints(endpoints, etcdShell string) error {
 func etcdctlHealthCheck(config *rest.Config, etcdShellPodName, etcdShellPodNS string, endpoints []string) error {
 	for _, endpoint := range endpoints {
 		errStr := fmt.Sprintf("%s%s", "failed to validate ETCD endpoints: ", endpoint)
+
+		// use dummy key/value pair 'foo'/'bar' to write to, read from & delete from etcd
+		// in order to validate each endpoint
 		key, value := "foo", "bar"
+
 		_, stderr, err := pluginutils.ExecToPod(config, etcdctlPutCmd(endpoint, key, value), "", etcdShellPodName, etcdShellPodNS, nil)
 		if err != nil {
 			return fmt.Errorf(fmt.Sprintf("%s%v", errStr, err))

--- a/pkg/installer/etcdctl.go
+++ b/pkg/installer/etcdctl.go
@@ -43,8 +43,8 @@ func etcdctlDelCmd(endpoints, key string) []string {
 // endpointsSplitter takes endpoints input from user prompt and returns digestable string for etcdctl
 // Example:
 // input: 1.2.3.4:2379,4.5.6.7:2379
-// output: "http://1.2.3.4:2379,http://4.5.6.7:2379"
-func endpointsSplitter(endpoints string) string {
+// output: {"http://1.2.3.4:2379","http://4.5.6.7:2379"}
+func endpointsSplitter(endpoints string) []string {
 	endpointsSlice := strings.Split(endpoints, ",")
 	httpEndpointsSlice := make([]string, 0)
 	for _, endpoint := range endpointsSlice {
@@ -54,5 +54,5 @@ func endpointsSplitter(endpoints string) string {
 		httpEndpointsSlice = append(httpEndpointsSlice, endpoint)
 	}
 
-	return strings.Join([]string{"\"", strings.Join(httpEndpointsSlice, ","), "\""}, "")
+	return httpEndpointsSlice
 }

--- a/pkg/installer/etcdctl_test.go
+++ b/pkg/installer/etcdctl_test.go
@@ -9,37 +9,37 @@ func TestEndpointsSplitter(t *testing.T) {
 	tcases := []struct {
 		name         string
 		endpoints    string
-		expEndpoints string
+		expEndpoints []string
 	}{
 		{
 			name:         "multiple IPs",
 			endpoints:    "1.2.3.4:2379,5.6.7.8:2379",
-			expEndpoints: "\"http://1.2.3.4:2379,http://5.6.7.8:2379\"",
+			expEndpoints: []string{"http://1.2.3.4:2379", "http://5.6.7.8:2379"},
 		},
 		{
 			name:         "single IP",
 			endpoints:    "1.2.3.4:2379",
-			expEndpoints: "\"http://1.2.3.4:2379\"",
+			expEndpoints: []string{"http://1.2.3.4:2379"},
 		},
 		{
 			name:         "domain",
 			endpoints:    "storageos.default:2379",
-			expEndpoints: "\"http://storageos.default:2379\"",
+			expEndpoints: []string{"http://storageos.default:2379"},
 		},
 		{
 			name:         "multiple domains",
 			endpoints:    "storageos.default:2379,storageos.system:2379",
-			expEndpoints: "\"http://storageos.default:2379,http://storageos.system:2379\"",
+			expEndpoints: []string{"http://storageos.default:2379", "http://storageos.system:2379"},
 		},
 		{
 			name:         "multiple domains with prefix",
 			endpoints:    "http://storageos.default:2379,http://storageos.system:2379",
-			expEndpoints: "\"http://storageos.default:2379,http://storageos.system:2379\"",
+			expEndpoints: []string{"http://storageos.default:2379", "http://storageos.system:2379"},
 		},
 	}
 	for _, tc := range tcases {
 		endpoints := endpointsSplitter(tc.endpoints)
-		if endpoints != tc.expEndpoints {
+		if !reflect.DeepEqual(endpoints, tc.expEndpoints) {
 			t.Errorf("expected %s, got %s", tc.expEndpoints, endpoints)
 		}
 	}
@@ -53,22 +53,22 @@ func TestEtcdctlMemberList(t *testing.T) {
 	}{
 		{
 			name:      "test 1",
-			endpoints: "\"http://1.2.3.4:2379,http://5.6.7.8:2379\"",
+			endpoints: "http://1.2.3.4:2379",
 			cmd: []string{
 				"etcdctl",
 				"--endpoints",
-				"\"http://1.2.3.4:2379,http://5.6.7.8:2379\"",
+				"http://1.2.3.4:2379",
 				"member",
 				"list",
 			},
 		},
 		{
 			name:      "test 2",
-			endpoints: "\"http://1.2.3.4:2379\"",
+			endpoints: "http://1.2.3.4:2379",
 			cmd: []string{
 				"etcdctl",
 				"--endpoints",
-				"\"http://1.2.3.4:2379\"",
+				"http://1.2.3.4:2379",
 				"member",
 				"list",
 			},
@@ -92,13 +92,13 @@ func TestEtcdctlPutCmd(t *testing.T) {
 	}{
 		{
 			name:      "test 1",
-			endpoints: "\"http://1.2.3.4:2379,http://5.6.7.8:2379\"",
+			endpoints: "http://1.2.3.4:2379",
 			key:       "foo",
 			value:     "bar",
 			cmd: []string{
 				"etcdctl",
 				"--endpoints",
-				"\"http://1.2.3.4:2379,http://5.6.7.8:2379\"",
+				"http://1.2.3.4:2379",
 				"put",
 				"foo",
 				"bar",
@@ -106,13 +106,13 @@ func TestEtcdctlPutCmd(t *testing.T) {
 		},
 		{
 			name:      "test 2",
-			endpoints: "\"http://1.2.3.4:2379\"",
+			endpoints: "http://1.2.3.4:2379",
 			key:       "test-key",
 			value:     "test-val",
 			cmd: []string{
 				"etcdctl",
 				"--endpoints",
-				"\"http://1.2.3.4:2379\"",
+				"http://1.2.3.4:2379",
 				"put",
 				"test-key",
 				"test-val",
@@ -136,24 +136,24 @@ func TestEtcdctlGetCmd(t *testing.T) {
 	}{
 		{
 			name:      "test 1",
-			endpoints: "\"http://1.2.3.4:2379,http://5.6.7.8:2379\"",
+			endpoints: "http://1.2.3.4:2379",
 			key:       "foo",
 			cmd: []string{
 				"etcdctl",
 				"--endpoints",
-				"\"http://1.2.3.4:2379,http://5.6.7.8:2379\"",
+				"http://1.2.3.4:2379",
 				"get",
 				"foo",
 			},
 		},
 		{
 			name:      "test 2",
-			endpoints: "\"http://1.2.3.4:2379\"",
+			endpoints: "http://1.2.3.4:2379",
 			key:       "test-key",
 			cmd: []string{
 				"etcdctl",
 				"--endpoints",
-				"\"http://1.2.3.4:2379\"",
+				"http://1.2.3.4:2379",
 				"get",
 				"test-key",
 			},
@@ -176,24 +176,24 @@ func TestEtcdctlDelCmd(t *testing.T) {
 	}{
 		{
 			name:      "test 1",
-			endpoints: "\"http://1.2.3.4:2379,http://5.6.7.8:2379\"",
+			endpoints: "http://1.2.3.4:2379",
 			key:       "foo",
 			cmd: []string{
 				"etcdctl",
 				"--endpoints",
-				"\"http://1.2.3.4:2379,http://5.6.7.8:2379\"",
+				"http://1.2.3.4:2379",
 				"del",
 				"foo",
 			},
 		},
 		{
 			name:      "test 2",
-			endpoints: "\"http://1.2.3.4:2379\"",
+			endpoints: "http://1.2.3.4:2379",
 			key:       "test-key",
 			cmd: []string{
 				"etcdctl",
 				"--endpoints",
-				"\"http://1.2.3.4:2379\"",
+				"http://1.2.3.4:2379",
 				"del",
 				"test-key",
 			},


### PR DESCRIPTION
Issues validating ETCD endpoints that are passed as comma delimited string.
This fix means each etcd endpoint is validated individually 