### PR TITLE
WIP upgrade calls installStorageOS

### DIFF
--- a/cmd/plugin/cli/install.go
+++ b/cmd/plugin/cli/install.go
@@ -90,7 +90,7 @@ func installCmd(config *apiv1.KubectlStorageOSConfig) error {
 		return err
 	}
 
-	err = cliInstaller.Install(config)
+	err = cliInstaller.Install(config, false)
 
 	return err
 }

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Install performs storageos operator and etcd operator installation for kubectl-storageos
-func (in *Installer) Install(config *apiv1.KubectlStorageOSConfig) error {
+func (in *Installer) Install(config *apiv1.KubectlStorageOSConfig, upgrade bool) error {
 	wg := sync.WaitGroup{}
 	errChan := make(chan error, 3)
 	if config.Spec.IncludeEtcd {
@@ -22,7 +22,7 @@ func (in *Installer) Install(config *apiv1.KubectlStorageOSConfig) error {
 
 			errChan <- in.installEtcd(config.Spec.Install)
 		}()
-	} else {
+	} else if !config.Spec.IncludeEtcd && !upgrade {
 		if err := in.handleEndpointsInput(config.Spec.Install); err != nil {
 			return err
 		}

--- a/pkg/installer/upgrade.go
+++ b/pkg/installer/upgrade.go
@@ -53,7 +53,7 @@ func Upgrade(uninstallConfig *apiv1.KubectlStorageOSConfig, installConfig *apiv1
 	time.Sleep(30 * time.Second)
 
 	// install new storageos operator and cluster
-	err = installer.Install(installConfig)
+	err = installer.Install(installConfig, true)
 
 	return err
 }


### PR DESCRIPTION
I know we had mentioned this on a previous PR somewhere, that we should just call `Install`... but doing so actually results in the etcd endpoints being validated twice. Calling `installStorageOS` fixes this.