### PR TITLE
Remove --stos-cluster-namespace for uninstall

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -122,7 +122,6 @@ Flags:
   -h, --help                             help for uninstall
       --include-etcd                     uninstall etcd (only applicable to github.com/storageos/etcd-cluster-operator etcd cluster)
       --skip-namespace-deletion          leaving namespaces untouched
-      --stos-cluster-namespace string    namespace of storageos cluster to be uninstalled (default "storageos")
       --stos-operator-namespace string   namespace of storageos operator to be uninstalled (default "storageos")
 ```
 
@@ -165,7 +164,6 @@ Flags:
       --skip-namespace-deletion                    leaving namespaces untouched
       --stos-cluster-yaml string                   storageos-cluster.yaml path or url to be installed
       --stos-operator-yaml string                  storageos-operator.yaml path or url to be installed
-      --uninstall-stos-cluster-namespace string    namespace of storageos cluster to be uninstalled (default "storageos")
       --uninstall-stos-operator-namespace string   namespace of storageos operator to be uninstalled (default "storageos")
       --version string                             version of storageos operator
       --wait                                       wait for storagos cluster to enter running phase
@@ -237,7 +235,6 @@ spec:
     storageOSClusterNamespace: storageos-cluster-new
   uninstall:
     storageOSOperatorNamespace: storageos-operator-old
-    storageOSClusterNamespace: storageos-cluster-old
 ```
 
 For an example config file, see:

--- a/api/v1/kubectlstorageosconfig_types.go
+++ b/api/v1/kubectlstorageosconfig_types.go
@@ -69,7 +69,6 @@ type Install struct {
 // Uninstall defines options for cli uninstall subcommand
 type Uninstall struct {
 	StorageOSOperatorNamespace string `json:"storageOSOperatorNamespace,omitempty"`
-	StorageOSClusterNamespace  string `json:"storageOSClusterNamespace,omitempty"`
 	EtcdNamespace              string `json:"etcdNamespace,omitempty"`
 }
 

--- a/cmd/plugin/cli/uninstall.go
+++ b/cmd/plugin/cli/uninstall.go
@@ -53,7 +53,6 @@ func UninstallCmd() *cobra.Command {
 	cmd.Flags().Bool(installer.IncludeEtcdFlag, false, "uninstall etcd (only applicable to github.com/storageos/etcd-cluster-operator etcd cluster)")
 	cmd.Flags().String(installer.EtcdNamespaceFlag, consts.EtcdOperatorNamespace, "namespace of etcd operator and cluster to be uninstalled")
 	cmd.Flags().String(installer.StosOperatorNSFlag, consts.NewOperatorNamespace, "namespace of storageos operator to be uninstalled")
-	cmd.Flags().String(installer.StosClusterNSFlag, consts.NewOperatorNamespace, "namespace of storageos cluster to be uninstalled")
 	cmd.Flags().String(installer.ConfigPathFlag, "", "path to look for kubectl-storageos-config.yaml")
 
 	viper.BindPFlags(cmd.Flags())
@@ -108,7 +107,6 @@ func setUninstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig
 			}
 			config.Spec.IncludeEtcd, _ = strconv.ParseBool(cmd.Flags().Lookup(installer.IncludeEtcdFlag).Value.String())
 			config.Spec.Uninstall.StorageOSOperatorNamespace = cmd.Flags().Lookup(installer.StosOperatorNSFlag).Value.String()
-			config.Spec.Uninstall.StorageOSClusterNamespace = cmd.Flags().Lookup(installer.StosClusterNSFlag).Value.String()
 			config.Spec.Uninstall.EtcdNamespace = cmd.Flags().Lookup(installer.EtcdNamespaceFlag).Value.String()
 			return nil
 		} else {
@@ -121,7 +119,6 @@ func setUninstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig
 	config.Spec.SkipNamespaceDeletion = viper.GetBool(installer.SkipNamespaceDeletionConfig)
 	config.Spec.IncludeEtcd = viper.GetBool(installer.IncludeEtcdConfig)
 	config.Spec.Uninstall.StorageOSOperatorNamespace = viper.GetString(installer.UninstallStosOperatorNSConfig)
-	config.Spec.Uninstall.StorageOSClusterNamespace = viper.GetString(installer.UninstallStosClusterNSConfig)
 	config.Spec.Uninstall.EtcdNamespace = valueOrDefault(viper.GetString(installer.UninstallEtcdNamespaceConfig), consts.EtcdOperatorNamespace)
 	return nil
 }

--- a/cmd/plugin/cli/upgrade.go
+++ b/cmd/plugin/cli/upgrade.go
@@ -20,7 +20,6 @@ import (
 const (
 	uninstallStosOperatorNSFlag = "uninstall-" + installer.StosOperatorNSFlag
 	installStosOperatorNSFlag   = "install-" + installer.StosOperatorNSFlag
-	uninstallStosClusterNSFlag  = "uninstall-" + installer.StosClusterNSFlag
 	installStosClusterNSFlag    = "install-" + installer.StosClusterNSFlag
 )
 
@@ -65,7 +64,6 @@ func UpgradeCmd() *cobra.Command {
 	cmd.Flags().Bool(installer.SkipNamespaceDeletionFlag, false, "leaving namespaces untouched")
 	cmd.Flags().String(installer.ConfigPathFlag, "", "path to look for kubectl-storageos-config.yaml")
 	cmd.Flags().String(uninstallStosOperatorNSFlag, consts.NewOperatorNamespace, "namespace of storageos operator to be uninstalled")
-	cmd.Flags().String(uninstallStosClusterNSFlag, consts.NewOperatorNamespace, "namespace of storageos cluster to be uninstalled")
 	cmd.Flags().String(installStosOperatorNSFlag, consts.NewOperatorNamespace, "namespace of storageos operator to be installed")
 	cmd.Flags().String(installStosClusterNSFlag, consts.NewOperatorNamespace, "namespace of storageos cluster to be installed")
 	cmd.Flags().String(installer.StosOperatorYamlFlag, "", "storageos-operator.yaml path or url to be installed")
@@ -190,7 +188,6 @@ func setUpgradeUninstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageO
 			}
 			config.Spec.IncludeEtcd = false
 			config.Spec.Uninstall.StorageOSOperatorNamespace = cmd.Flags().Lookup(uninstallStosOperatorNSFlag).Value.String()
-			config.Spec.Uninstall.StorageOSClusterNamespace = cmd.Flags().Lookup(uninstallStosClusterNSFlag).Value.String()
 			return nil
 		} else {
 			// Config file was found but another error was produced
@@ -201,6 +198,5 @@ func setUpgradeUninstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageO
 	config.Spec.SkipNamespaceDeletion = viper.GetBool(installer.SkipNamespaceDeletionConfig)
 	config.Spec.IncludeEtcd = false
 	config.Spec.Uninstall.StorageOSOperatorNamespace = viper.GetString(installer.UninstallStosOperatorNSConfig)
-	config.Spec.Uninstall.StorageOSClusterNamespace = viper.GetString(installer.UninstallStosClusterNSConfig)
 	return nil
 }

--- a/config/crd/bases/storageos.com_kubectlstorageosconfigs.yaml
+++ b/config/crd/bases/storageos.com_kubectlstorageosconfigs.yaml
@@ -94,8 +94,6 @@ spec:
                 properties:
                   etcdNamespace:
                     type: string
-                  storageOSClusterNamespace:
-                    type: string
                   storageOSOperatorNamespace:
                     type: string
                 type: object

--- a/config/samples/_v1_kubectlstorageosconfig.yaml
+++ b/config/samples/_v1_kubectlstorageosconfig.yaml
@@ -32,5 +32,4 @@ spec:
     storageClassName: "<storage-class>"
   uninstall:
     storageOSOperatorNamespace: "<storageos-operator-namespace>"
-    storageOSClusterNamespace: "<storageos-cluster-namespace>"
     etcdNamespace: "<etcd-namespace>"

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -66,7 +66,6 @@ const (
 	AdminPasswordConfig           = "spec.install.adminPassword"
 	UninstallEtcdNamespaceConfig  = "spec.uninstall.etcdNamespace"
 	UninstallStosOperatorNSConfig = "spec.uninstall.storageOSOperatorNamespace"
-	UninstallStosClusterNSConfig  = "spec.uninstall.storageOSClusterNamespace"
 
 	// dir and file names for in memory fs
 	etcdDir              = "etcd"

--- a/pkg/installer/uninstall.go
+++ b/pkg/installer/uninstall.go
@@ -77,8 +77,8 @@ func (in *Installer) uninstallStorageOS(uninstallConfig apiv1.Uninstall, upgrade
 		}
 	}
 	// StorageOS cluster resources should be in a different namespace, on that case need to delete
-	if in.stosConfig.Spec.Uninstall.StorageOSClusterNamespace != in.stosConfig.Spec.Uninstall.StorageOSOperatorNamespace {
-		if err = in.gracefullyDeleteNS(in.stosConfig.Spec.Uninstall.StorageOSClusterNamespace); err != nil {
+	if storageOSCluster.Namespace != in.stosConfig.Spec.Uninstall.StorageOSOperatorNamespace {
+		if err = in.gracefullyDeleteNS(storageOSCluster.Namespace); err != nil {
 			return err
 		}
 	}

--- a/tests/e2e/installer/01-uninstall.yaml
+++ b/tests/e2e/installer/01-uninstall.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl-storageos uninstall --stos-cluster-namespace=stos-cluster-install-full --stos-operator-namespace=stos-operator-install-full
+  - command: kubectl-storageos uninstall --stos-operator-namespace=stos-operator-install-full

--- a/tests/e2e/installer/04-uninstall.yaml
+++ b/tests/e2e/installer/04-uninstall.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl-storageos uninstall --stos-operator-namespace=stos-operator-install-skip-etcd --stos-cluster-namespace=stos-cluster-install-skip-etcd
+  - command: kubectl-storageos uninstall --stos-operator-namespace=stos-operator-install-skip-etcd

--- a/tests/e2e/installer/09-upgrade.yaml
+++ b/tests/e2e/installer/09-upgrade.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
         - command: sleep 2m
-        - command: kubectl-storageos upgrade --uninstall-stos-operator-namespace=storageos-operator --install-stos-operator-namespace=storageos
+        - command: kubectl-storageos upgrade --uninstall-stos-operator-namespace=storageos-operator --install-stos-operator-namespace=storageos --skip-namespace-deletion

--- a/tests/e2e/installer/kubectl-storageos-config.yaml
+++ b/tests/e2e/installer/kubectl-storageos-config.yaml
@@ -11,4 +11,3 @@ spec:
     storageClassName: standard
   uninstall:
     storageOSOperatorNamespace: stos-operator-install-skip-etcd-config
-    storageOSClusterNamespace: stos-cluster-install-skip-etcd-config


### PR DESCRIPTION
The storageOS cluster object is already discovered without the need for namespace by `GetFirstStorageOSCluster`, so this flag is not needed for uninstall step.