### PR TITLE
Remove flag descriptions from root cmd

### DIFF
--- a/cmd/plugin/cli/root.go
+++ b/cmd/plugin/cli/root.go
@@ -66,9 +66,6 @@ func RootCmd() *cobra.Command {
 
 	cobra.OnInitialize(initConfig)
 
-	KubernetesConfigFlags = genericclioptions.NewConfigFlags(false)
-	KubernetesConfigFlags.AddFlags(cmd.Flags())
-
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	cmd.AddCommand(PreflightCmd())


### PR DESCRIPTION
There are a bunch of flags listed on the root command 'help' which don't apply to most sub commands.
The flags removed here still exist in preflight and bundle subcommands where they are actually applicable.