### PR TITLE
Backup portal configmap to disk

### DIFF
--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -365,7 +365,7 @@ func (in *Installer) writeBackupFileSystem(storageOSCluster *operatorapi.Storage
 		return errors.WithStack(err)
 	}
 
-	configMapList, err := in.listStorageOSConfigMaps()
+	configMapList, err := pluginutils.ListConfigMaps(in.clientConfig, metav1.ListOptions{LabelSelector: stosAppLabel})
 	if err != nil {
 		return err
 	}
@@ -388,19 +388,6 @@ func (in *Installer) listStorageOSStorageClasses() (*kstoragev1.StorageClassList
 	}
 
 	return stosStorageClassList, nil
-}
-
-func (in *Installer) listStorageOSConfigMaps() (*corev1.ConfigMapList, error) {
-	configMapList, err := pluginutils.ListConfigMaps(in.clientConfig, metav1.ListOptions{LabelSelector: stosAppLabel})
-	if err != nil {
-		return nil, err
-	}
-	stosConfigMapList := &corev1.ConfigMapList{}
-	for _, configMap := range configMapList.Items {
-		stosConfigMapList.Items = append(stosConfigMapList.Items, configMap)
-	}
-
-	return stosConfigMapList, nil
 }
 
 // writeSecretsToDisk writes multidoc manifest of SecretList.Items to path of on-disk filesystem

--- a/pkg/installer/upgrade.go
+++ b/pkg/installer/upgrade.go
@@ -70,6 +70,11 @@ func (in *Installer) prepareForUpgrade(installConfig *apiv1.KubectlStorageOSConf
 		return err
 	}
 
+	// apply the configmap manifest written to disk (now with finalizer to prevent deletion by operator)
+	if err := in.applyBackupManifestWithFinalizer(stosConfigMapsFile); err != nil {
+		return err
+	}
+
 	// if the version being uninstalled during upgrade is that of the 'old' operator (pre v2.5) existing
 	// CSI secrets are applied with finalizer to prevent deletion by operator
 	oldVersion, err := pluginversion.VersionIsLessThanOrEqual(versionToUninstall, pluginversion.ClusterOperatorLastVersion())

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -488,6 +488,20 @@ func ListPersistentVolumeClaims(config *rest.Config, listOptions metav1.ListOpti
 	return pvcs, nil
 }
 
+// ListConfigMaps returns ConfigMapList
+func ListConfigMaps(config *rest.Config, listOptions metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	clientset, err := GetClientsetFromConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	configMaps, err := clientset.CoreV1().ConfigMaps("").List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return configMaps, nil
+}
+
 // CreateStorageClass creates k8s storage class.
 func CreateStorageClass(config *rest.Config, storageClass *kstoragev1.StorageClass) error {
 	clientset, err := GetClientsetFromConfig(config)


### PR DESCRIPTION
Backs up any storageos labelled configmaps to disk, which will include portal configmap. Secrets are already taken care of.