### PR TITLE
Int 375 plugin upgrade restores wrong portal user and secret

### DIFF
--- a/cmd/plugin/cli/install-portal.go
+++ b/cmd/plugin/cli/install-portal.go
@@ -50,8 +50,6 @@ func InstallPortalCmd() *cobra.Command {
 	cmd.Flags().String(installer.StosPortalConfigYamlFlag, "", "storageos-portal-configmap.yaml path or url")
 	cmd.Flags().String(installer.StosClusterNSFlag, consts.NewOperatorNamespace, "namespace of storageos cluster")
 	cmd.Flags().String(installer.StosOperatorNSFlag, consts.NewOperatorNamespace, "namespace of storageos operator")
-	cmd.Flags().String(installer.AdminUsernameFlag, "", "storageos portal clientID (plaintext)")
-	cmd.Flags().String(installer.AdminPasswordFlag, "", "storageos portal password (plaintext)")
 	cmd.Flags().String(installer.TenantIDFlag, "", "storageos tenant id")
 	cmd.Flags().String(installer.PortalAPIURLFlag, "", "storageos portal url")
 
@@ -69,7 +67,10 @@ func installPortalCmd(config *apiv1.KubectlStorageOSConfig) error {
 	if err := versionSupportsPortal(existingOperatorVersion); err != nil {
 		return err
 	}
-	if err := installer.PortalFlagsExist(config); err != nil {
+	if err := installer.FlagsAreSet(map[string]string{
+		installer.TenantIDFlag:     config.Spec.Install.TenantID,
+		installer.PortalAPIURLFlag: config.Spec.Install.PortalAPIURL,
+	}); err != nil {
 		return err
 	}
 

--- a/cmd/plugin/cli/install-portal.go
+++ b/cmd/plugin/cli/install-portal.go
@@ -106,8 +106,6 @@ func setInstallPortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSCo
 		config.Spec.Install.StorageOSPortalConfigYaml = cmd.Flags().Lookup(installer.StosPortalConfigYamlFlag).Value.String()
 		config.Spec.Install.StorageOSClusterNamespace = cmd.Flags().Lookup(installer.StosClusterNSFlag).Value.String()
 		config.Spec.Install.StorageOSOperatorNamespace = cmd.Flags().Lookup(installer.StosOperatorNSFlag).Value.String()
-		config.Spec.Install.AdminUsername = cmd.Flags().Lookup(installer.AdminUsernameFlag).Value.String()
-		config.Spec.Install.AdminPassword = cmd.Flags().Lookup(installer.AdminPasswordFlag).Value.String()
 		config.Spec.Install.PortalAPIURL = cmd.Flags().Lookup(installer.PortalAPIURLFlag).Value.String()
 		config.Spec.Install.TenantID = cmd.Flags().Lookup(installer.TenantIDFlag).Value.String()
 		return nil
@@ -117,8 +115,6 @@ func setInstallPortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSCo
 	config.Spec.Install.StorageOSPortalConfigYaml = viper.GetString(installer.StosPortalConfigYamlConfig)
 	config.Spec.Install.StorageOSClusterNamespace = viper.GetString(installer.StosClusterNSConfig)
 	config.Spec.Install.StorageOSOperatorNamespace = viper.GetString(installer.InstallStosOperatorNSConfig)
-	config.Spec.Install.AdminUsername = viper.GetString(installer.AdminUsernameConfig)
-	config.Spec.Install.AdminPassword = viper.GetString(installer.AdminPasswordConfig)
 	config.Spec.Install.PortalAPIURL = viper.GetString(installer.PortalAPIURLConfig)
 	config.Spec.Install.TenantID = viper.GetString(installer.TenantIDConfig)
 	return nil

--- a/cmd/plugin/cli/install.go
+++ b/cmd/plugin/cli/install.go
@@ -84,7 +84,12 @@ func installCmd(config *apiv1.KubectlStorageOSConfig) error {
 		if err := versionSupportsPortal(config.Spec.Install.StorageOSVersion); err != nil {
 			return err
 		}
-		if err := installer.PortalFlagsExist(config); err != nil {
+		if err := installer.FlagsAreSet(map[string]string{
+			installer.AdminUsernameFlag: config.Spec.Install.AdminUsername,
+			installer.AdminPasswordFlag: config.Spec.Install.AdminPassword,
+			installer.TenantIDFlag:      config.Spec.Install.TenantID,
+			installer.PortalAPIURLFlag:  config.Spec.Install.PortalAPIURL,
+		}); err != nil {
 			return err
 		}
 	}

--- a/e2e/tests/stable/installer/14-install-portal.yaml
+++ b/e2e/tests/stable/installer/14-install-portal.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl storageos install-portal --admin-username=storageos --admin-password=storageos --portal-api-url=www.foo.com --tenant-id=storageos
+  - command: kubectl storageos install-portal --portal-api-url=www.foo.com --tenant-id=storageos

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -269,10 +269,12 @@ func (in *Installer) installStorageOS() error {
 	}
 
 	if in.stosConfig.Spec.Install.EnablePortalManager {
-		if err := in.InstallPortalManager(); err != nil {
+		if err := in.installPortalManagerClient(); err != nil {
 			return err
 		}
-
+		if err := in.installPortalManagerConfig(); err != nil {
+			return err
+		}
 		if err := in.enablePortalManager(fsStosClusterName, true); err != nil {
 			return err
 		}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -441,4 +442,44 @@ func (in *Installer) getBackupPath() (string, error) {
 		return "", errors.WithStack(err)
 	}
 	return filepath.Join(homeDir, kubeDir, stosDir, fmt.Sprintf("%s%v", uninstallDirPrefix, in.kubeClusterID)), nil
+}
+
+func (in *Installer) getDecodedAPISecretUsername(storageosAPISecret string) (string, error) {
+	secretUsername, err := pluginutils.GetFieldInManifest(storageosAPISecret, "data", "username")
+	if err != nil {
+		return "", err
+	}
+	if secretUsername == "" {
+		// also check for apiUsername (pre 2.5.0)
+		secretUsername, err = pluginutils.GetFieldInManifest(storageosAPISecret, "data", "apiUsername")
+		if err != nil {
+			return "", err
+		}
+	}
+	decodedSecretUsername, err := base64.StdEncoding.DecodeString(secretUsername)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return string(decodedSecretUsername), nil
+}
+
+func (in *Installer) getDecodedAPISecretPassword(storageosAPISecret string) (string, error) {
+	secretPassword, err := pluginutils.GetFieldInManifest(storageosAPISecret, "data", "password")
+	if err != nil {
+		return "", err
+	}
+	if secretPassword == "" {
+		// also check for apiPassword (pre 2.5.0)
+		secretPassword, err = pluginutils.GetFieldInManifest(storageosAPISecret, "data", "apiPassword")
+		if err != nil {
+			return "", err
+		}
+	}
+	decodedSecretPassword, err := base64.StdEncoding.DecodeString(secretPassword)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return string(decodedSecretPassword), nil
 }

--- a/pkg/installer/utils.go
+++ b/pkg/installer/utils.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 )
 
+const errFlagsNotSet = "The following flags have not been set and are required to perform this command:"
+
 // buildInstallerFileSys builds an in-memory filesystem for installer with relevant storageos and
 // etcd manifests.
 // If '--skip-etcd-install' flag is set, etcd dir is not created
@@ -438,4 +440,19 @@ func collectErrors(errChan <-chan error) error {
 			mErr.errors = append(mErr.errors, err.Error())
 		}
 	}
+}
+
+// FlagsAreSet takes a map[string]string of flag-name:flag-value and returns an error listing
+// all flag-names in 'flags' map that have not been set.
+func FlagsAreSet(flags map[string]string) error {
+	missingFlags := make([]string, 0)
+	for flagName, flagValue := range flags {
+		if flagValue == "" {
+			missingFlags = append(missingFlags, flagName)
+		}
+	}
+	if len(missingFlags) != 0 {
+		return fmt.Errorf(errFlagsNotSet + strings.Join(missingFlags, ","))
+	}
+	return nil
 }


### PR DESCRIPTION
From ticket:
```
I think what’s happening is that a basic install can be done with admin-username and admin-password. 
But then a user can come along and install-portal-manager with a different admin-username and admin-password. 
Hence it’s possible to end up in this situation for an upgrade as we have two sets of data.
For me, the solution is to remove admin-username and admin-password flags from install-portal-manager command, 
instead populate them from the existing secret - with this change we’ll have only one source of truth and 
the existing funcitonality should work as expected. 
```