### PR TITLE
Add script to edit kind versions and repo dispatch workflow

### DIFF
--- a/.github/workflows/generate-tests.yaml
+++ b/.github/workflows/generate-tests.yaml
@@ -1,0 +1,26 @@
+name: Generate tests for new kind-node image
+
+on: 
+  repository_dispatch:
+    types: [generate-tests]           
+
+jobs:
+  test:
+    name: Generate test files
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Trim version
+        run: echo "LATEST_KIND_NODE=$(echo ${{ github.event.client_payload.latest-kind-node }} | tr -d '[:v]')" >> $GITHUB_ENV
+      - name: Generate and commit tests
+        run: |
+          make update-kind-nodes
+          make generate-tests      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Generated test files for new kind node image and removed test files for oldest kind node image."
+          branch: "new-kind-node-image"
+          title: "Auto-generated: Update kuttl e2e test  files"
+          delete-branch: true

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,12 @@ endif
 
 KUBECTL_STOS_VERSION ?= v1.0.0
 
-# Generate kuttl e2e tests for the following storageos/kind-node versions.
+# Generate kuttl e2e tests for the following storageos/kind-node versions
+# TEST_KIND_NODES is not intended to be updated manually.
+# Please edit LATEST_KIND_NODE instead and run 'make update-kind-nodes'.
 TEST_KIND_NODES ?= 1.18.6,1.19.0,1.20.5,1.21.0,1.22.3
+
+LATEST_KIND_NODE ?= 1.22.3
 REPO ?= kubectl-storageos
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
@@ -81,6 +85,9 @@ _build-pre: ## Build manager binary.
 
 run: fmt vet generate ## Run a controller from your host.
 	go run ./main.go
+
+update-kind-nodes: 
+	LATEST_KIND_NODE=$(LATEST_KIND_NODE) ./hack/update-kind-nodes.sh
 
 generate-tests: ## Generate kuttl e2e tests
 	TEST_KIND_NODES=$(TEST_KIND_NODES) REPO=$(REPO) ./hack/generate-tests.sh

--- a/hack/update-kind-nodes.sh
+++ b/hack/update-kind-nodes.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+: "${LATEST_KIND_NODE? = required}"
+
+sed -i "/^TEST_KIND_NODES/ s/$/,${LATEST_KIND_NODE}/" Makefile
+sed -i 's|\(TEST_KIND_NODES ?=\)[^,]*|\1|' Makefile
+sed -i '/^TEST_KIND_NODES/ s/?=,/?= /g' Makefile
+


### PR DESCRIPTION
This PR creates a new script to update the kind-node versions to be tested, and a new workflow to auto-generate a PR with the newly generated test files. This workflow will be triggered by each new kind node image build as per https://github.com/storageos/kind-node-image-releaser/pull/5 