### PR TITLE
Store dry run result in a unique directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ kubeconfig
 support-bundle*.tar.gz
 
 # dry-run directory
-storageos-dry-run
+storageos-dry-run*

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 
-	"github.com/pkg/errors"
 	pluginutils "github.com/storageos/kubectl-storageos/pkg/utils"
 	"sigs.k8s.io/kustomize/api/krusty"
 )
@@ -370,7 +368,7 @@ func (in *Installer) kustomizeAndApply(dir, file string) error {
 	}
 
 	if in.stosConfig.Spec.Install.DryRun {
-		if err := writeDryRunManifests(file, resYaml); err != nil {
+		if err := pluginutils.WriteDryRunManifests(file, resYaml); err != nil {
 			return err
 		}
 		// return early for dry-run without applying manifest
@@ -413,20 +411,4 @@ func (in *Installer) gracefullyApplyNS(namespaceManifest string) error {
 	}, 120, 5)
 
 	return err
-}
-
-func writeDryRunManifests(filename string, fileData []byte) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	if _, err = os.Stat(filepath.Join(cwd, stosDryRunDir)); err != nil {
-		if err = os.Mkdir(filepath.Join(cwd, stosDryRunDir), 0770); err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	if err = os.WriteFile(filepath.Join(cwd, stosDryRunDir, filename), fileData, 0640); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
 }

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -111,7 +111,6 @@ const (
 	kustomizationFile    = "kustomization.yaml"
 	kubeDir              = ".kube"
 	uninstallDirPrefix   = "uninstall-"
-	stosDryRunDir        = "storageos-dry-run"
 
 	// kustomization template
 	kustTemp = `apiVersion: kustomize.config.k8s.io/v1beta1

--- a/pkg/utils/dryrun.go
+++ b/pkg/utils/dryrun.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const stosDryRunDir = "./storageos-dry-run"
+
+var dryRunWriterService = dryRunWriter{
+	lock: make(chan bool, 1),
+}
+
+type dryRunWriter struct {
+	path string
+	lock chan bool
+}
+
+func (w *dryRunWriter) writeDryRunManifests(filename string, fileData []byte) error {
+	w.lock <- true
+	defer func() {
+		<-w.lock
+	}()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if w.path == "" {
+		w.path = stosDryRunDir
+		if _, err = os.Stat(filepath.Join(cwd, w.path)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return errors.WithStack(err)
+		} else if err == nil {
+			w.path = fmt.Sprintf("%s-%d", stosDryRunDir, time.Now().UnixNano())
+		}
+
+		if err = os.Mkdir(filepath.Join(cwd, w.path), 0770); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(cwd, w.path, filename), fileData, 0640); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+// WriteDryRunManifests protects existing dry run output by postfixing directory.
+// This function is used more than 1 time during the manifests generation,
+// So it reuses the same directory for eaach run in a thread safe manner.
+func WriteDryRunManifests(filename string, fileData []byte) error {
+	return dryRunWriterService.writeDryRunManifests(filename, fileData)
+}


### PR DESCRIPTION
This PR introduces a thread safe dry run writer service, which avoids overwriting an existing dry run result.