### PR TITLE
Remove check for dry-run

### DIFF
--- a/e2e/tests/dry-run/dry-run-test.sh
+++ b/e2e/tests/dry-run/dry-run-test.sh
@@ -9,7 +9,7 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf -- "$TMPDIR"' EXIT
 
 # Run install --dry-run command and move output to tmpdir
-kubectl storageos install --dry-run --k8s-version=v1.22.0 --etcd-endpoints=storageos-etcd.storageos-etcd:2379
+kubectl storageos install --dry-run --k8s-version=v1.22.0 --etcd-endpoints=storageos.etcd:2379
 cp -r storageos-dry-run $TMPDIR/ && rm -r storageos-dry-run
 # Fetch operator-manifests and store in temp dir
 docker run "storageos/operator-manifests:v${LATEST_VERSION}" > ${TMPDIR}/storageos-operator.yaml

--- a/e2e/tests/dry-run/test-data/storageos-cluster.yaml
+++ b/e2e/tests/dry-run/test-data/storageos-cluster.yaml
@@ -16,6 +16,6 @@ metadata:
   namespace: storageos
 spec:
   kvBackend:
-    address: storageos-etcd.storageos-etcd:2379
+    address: storageos.etcd:2379
   secretRefName: storageos-api
   storageClassName: storageos

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -22,7 +22,7 @@ func (in *Installer) Install(upgrade bool) error {
 
 			errChan <- in.installEtcd()
 		}()
-	} else if !in.stosConfig.Spec.Install.DryRun && !upgrade {
+	} else if !upgrade {
 		if err := in.handleEndpointsInput(in.stosConfig.Spec.Install); err != nil {
 			return err
 		}


### PR DESCRIPTION
The `handleEndpointsInput` func should be called in any case (dry-run or not), it is the validation step we want to skip - and this is already taken care of here https://github.com/storageos/kubectl-storageos/blob/8bb4243a3c4ac078cf6889d1a804edf2e33d3f10/cmd/plugin/cli/install.go#L124 