### PR TITLE
Detect skip namespace deletion instead of terminal detection

### DIFF
--- a/cmd/plugin/cli/disable-portal.go
+++ b/cmd/plugin/cli/disable-portal.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
@@ -85,7 +84,7 @@ func setDisablePortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSCo
 			return fmt.Errorf("error discovered in config file: %v", err)
 		}
 		// Config file not found; set fields in new config object directly
-		config.Spec.StackTrace, err = strconv.ParseBool(cmd.Flags().Lookup(installer.StackTraceFlag).Value.String())
+		config.Spec.StackTrace, err = cmd.Flags().GetBool(installer.StackTraceFlag)
 		if err != nil {
 			return err
 		}

--- a/cmd/plugin/cli/enable-portal.go
+++ b/cmd/plugin/cli/enable-portal.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
@@ -85,7 +84,7 @@ func setEnablePortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSCon
 			return fmt.Errorf("error discovered in config file: %v", err)
 		}
 		// Config file not found; set fields in new config object directly
-		config.Spec.StackTrace, err = strconv.ParseBool(cmd.Flags().Lookup(installer.StackTraceFlag).Value.String())
+		config.Spec.StackTrace, err = cmd.Flags().GetBool(installer.StackTraceFlag)
 		if err != nil {
 			return err
 		}

--- a/cmd/plugin/cli/install-portal.go
+++ b/cmd/plugin/cli/install-portal.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
@@ -103,7 +102,7 @@ func setInstallPortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSCo
 			return fmt.Errorf("error discovered in config file: %v", err)
 		}
 		// Config file not found; set fields in new config object directly
-		config.Spec.StackTrace, err = strconv.ParseBool(cmd.Flags().Lookup(installer.StackTraceFlag).Value.String())
+		config.Spec.StackTrace, err = cmd.Flags().GetBool(installer.StackTraceFlag)
 		if err != nil {
 			return err
 		}

--- a/cmd/plugin/cli/install.go
+++ b/cmd/plugin/cli/install.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
@@ -162,35 +161,35 @@ func setInstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) 
 			return fmt.Errorf("error discovered in config file: %v", err)
 		}
 		// Config file not found; set fields in new config object directly
-		config.Spec.StackTrace, err = strconv.ParseBool(cmd.Flags().Lookup(installer.StackTraceFlag).Value.String())
+		config.Spec.StackTrace, err = cmd.Flags().GetBool(installer.StackTraceFlag)
 		if err != nil {
 			return err
 		}
-		config.Spec.IncludeEtcd, err = strconv.ParseBool(cmd.Flags().Lookup(installer.IncludeEtcdFlag).Value.String())
+		config.Spec.IncludeEtcd, err = cmd.Flags().GetBool(installer.IncludeEtcdFlag)
 		if err != nil {
 			return err
 		}
-		config.Spec.SkipStorageOSCluster, err = strconv.ParseBool(cmd.Flags().Lookup(installer.SkipStosClusterFlag).Value.String())
+		config.Spec.SkipStorageOSCluster, err = cmd.Flags().GetBool(installer.SkipStosClusterFlag)
 		if err != nil {
 			return err
 		}
-		config.Spec.Install.EnablePortalManager, err = strconv.ParseBool(cmd.Flags().Lookup(installer.EnablePortalManagerFlag).Value.String())
+		config.Spec.Install.EnablePortalManager, err = cmd.Flags().GetBool(installer.EnablePortalManagerFlag)
 		if err != nil {
 			return err
 		}
-		config.Spec.Install.Wait, err = strconv.ParseBool(cmd.Flags().Lookup(installer.WaitFlag).Value.String())
+		config.Spec.Install.Wait, err = cmd.Flags().GetBool(installer.WaitFlag)
 		if err != nil {
 			return err
 		}
-		config.Spec.Install.DryRun, err = strconv.ParseBool(cmd.Flags().Lookup(installer.DryRunFlag).Value.String())
+		config.Spec.Install.DryRun, err = cmd.Flags().GetBool(installer.DryRunFlag)
 		if err != nil {
 			return err
 		}
-		config.Spec.Install.SkipEtcdEndpointsValidation, err = strconv.ParseBool(cmd.Flags().Lookup(installer.SkipEtcdEndpointsValFlag).Value.String())
+		config.Spec.Install.SkipEtcdEndpointsValidation, err = cmd.Flags().GetBool(installer.SkipEtcdEndpointsValFlag)
 		if err != nil {
 			return err
 		}
-		config.Spec.Install.EtcdTLSEnabled, err = strconv.ParseBool(cmd.Flags().Lookup(installer.EtcdTLSEnabledFlag).Value.String())
+		config.Spec.Install.EtcdTLSEnabled, err = cmd.Flags().GetBool(installer.EtcdTLSEnabledFlag)
 		if err != nil {
 			return err
 		}

--- a/cmd/plugin/cli/uninstall-portal.go
+++ b/cmd/plugin/cli/uninstall-portal.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
@@ -89,7 +88,7 @@ func setUninstallPortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOS
 			return fmt.Errorf("error discovered in config file: %v", err)
 		}
 		// Config file not found; set fields in new config object directly
-		config.Spec.StackTrace, err = strconv.ParseBool(cmd.Flags().Lookup(installer.StackTraceFlag).Value.String())
+		config.Spec.StackTrace, err = cmd.Flags().GetBool(installer.StackTraceFlag)
 		if err != nil {
 			return err
 		}

--- a/e2e/tests/installer/stable/kubectl-storageos/01-uninstall.yaml
+++ b/e2e/tests/installer/stable/kubectl-storageos/01-uninstall.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl-storageos uninstall --stos-operator-namespace=stos-operator-install-full
+  - command: kubectl-storageos uninstall --stos-operator-namespace=stos-operator-install-full --skip-namespace-deletion=false

--- a/e2e/tests/installer/stable/kubectl-storageos/04-uninstall.yaml
+++ b/e2e/tests/installer/stable/kubectl-storageos/04-uninstall.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl-storageos uninstall --stos-operator-namespace=stos-operator-install-skip-etcd
+  - command: kubectl-storageos uninstall --stos-operator-namespace=stos-operator-install-skip-etcd --skip-namespace-deletion=false

--- a/e2e/tests/installer/stable/kubectl-storageos/06-uninstall.yaml
+++ b/e2e/tests/installer/stable/kubectl-storageos/06-uninstall.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl-storageos uninstall --stos-operator-namespace=stos-operator-install-skip-etcd-config
+  - command: kubectl-storageos uninstall --stos-operator-namespace=stos-operator-install-skip-etcd-config --skip-namespace-deletion=false

--- a/e2e/tests/installer/stable/kubectl-storageos/10-uninstall-full.yaml
+++ b/e2e/tests/installer/stable/kubectl-storageos/10-uninstall-full.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl-storageos uninstall --etcd-namespace=etcd-install-full --stos-operator-namespace=stos-operator-install-skip-etcd-cluster --include-etcd --skip-stos-cluster --skip-namespace-deletion
+  - command: kubectl-storageos uninstall --etcd-namespace=etcd-install-full --stos-operator-namespace=stos-operator-install-skip-etcd-cluster --include-etcd --skip-stos-cluster --skip-namespace-deletion=true

--- a/e2e/tests/installer/stable/kubectl-storageos/12-uninstall.yaml
+++ b/e2e/tests/installer/stable/kubectl-storageos/12-uninstall.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl-storageos uninstall --skip-namespace-deletion 
+  - command: kubectl-storageos uninstall --skip-namespace-deletion=true

--- a/e2e/tests/upgrade/stable/kubectl-storageos/09-upgrade.yaml
+++ b/e2e/tests/upgrade/stable/kubectl-storageos/09-upgrade.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
         - command: sleep 2m
-        - command: kubectl-storageos upgrade
+        - command: kubectl-storageos upgrade --skip-namespace-deletion

--- a/pkg/installer/uninstall.go
+++ b/pkg/installer/uninstall.go
@@ -119,7 +119,7 @@ func (in *Installer) uninstallStorageOS(upgrade bool, currentVersion string) err
 		}
 		defer func() {
 			if err := in.gracefullyDeleteNS(in.storageOSCluster.Namespace); err != nil {
-				panic(err)
+				println(err.Error())
 			}
 		}()
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,10 +4,13 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -22,6 +25,23 @@ import (
 )
 
 const promptTimeout = time.Minute
+
+var parseFlagsOnce = sync.Once{}
+
+// HasFlagSet detects user given flag
+func HasFlagSet(name string) bool {
+	parseFlagsOnce.Do(func() {
+		flag.Parse()
+	})
+
+	for _, arg := range flag.Args() {
+		if strings.HasPrefix(arg, "--"+name) {
+			return true
+		}
+	}
+
+	return false
+}
 
 // AskUser creates an interactive prompt and waits for user input with timeout
 func AskUser(prompt promptui.Prompt) (string, error) {


### PR DESCRIPTION
Before the change:

kubectl-storageos uninstall                                
false
Error: prompt

OK

kubectl-storageos uninstall --skip-namespace-deletion
true
Error: no prompt

OK

kubectl-storageos uninstall --skip-namespace-deletion="true"
true
Error: no prompt

OK

kubectl-storageos uninstall --skip-namespace-deletion="false"
false
Error: prompt

BAD

After change:
Ask only if flag has not given.