### PR TITLE
Always install serially for dry-run

### DIFF
--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -30,7 +30,7 @@ func (in *Installer) Install(upgrade bool) error {
 		}
 	}
 
-	if serialInstall {
+	if serialInstall || in.stosConfig.Spec.Install.DryRun {
 		wg.Wait()
 	}
 


### PR DESCRIPTION
Install serially for dry-run so that manifests are numbered correctly (i.e. ETCD manifests are ordered before StorageOS manifests)