### PR TITLE
Introduce live build with Air

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,37 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./bin/kubectl-storageos version"
+  cmd = "go build -tags 'exclude_graphdriver_btrfs exclude_graphdriver_devicemapper' -o ./bin/kubectl-storageos ."
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go"]
+  kill_delay = "0s"
+  log = "build-errors.log"
+  send_interrupt = false
+  stop_on_error = true
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ support-bundle*.tar.gz
 
 # dry-run directory
 storageos-dry-run*
+
+# air errer logs
+build-errors.log

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 AIR = $(shell pwd)/bin/air
 air: ## Download air locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),github.com/cosmtrek/air@v1.40.1)
+	$(call go-get-tool,$(AIR),github.com/cosmtrek/air@v1.40.1)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ e2e: ## Run e2e tests against latest supported k8s cluster.
 
 ##@ Build
 
+airbuild: air ## runs live build for development.
+	air -c .air.toml
+
 build: test ## test and build manager binary.
 	make _build
 
@@ -118,6 +121,10 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+
+AIR = $(shell pwd)/bin/air
+air: ## Download air locally if necessary.
+	$(call go-get-tool,$(KUSTOMIZE),github.com/cosmtrek/air@v1.40.1)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
Execute `make airbuild` on your local dev machine, and air would rebuild the project each time you change it.