### PR TITLE
retry on conflict

### DIFF
--- a/cmd/plugin/cli/disable-portal.go
+++ b/cmd/plugin/cli/disable-portal.go
@@ -6,6 +6,8 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/util/retry"
+
 	apiv1 "github.com/storageos/kubectl-storageos/api/v1"
 	"github.com/storageos/kubectl-storageos/pkg/consts"
 	"github.com/storageos/kubectl-storageos/pkg/installer"
@@ -63,12 +65,14 @@ func disablePortalCmd(config *apiv1.KubectlStorageOSConfig) error {
 		return err
 	}
 
-	cliInstaller, err := installer.NewPortalManagerInstaller(config, false)
-	if err != nil {
-		return err
-	}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		cliInstaller, err := installer.NewPortalManagerInstaller(config, false)
+		if err != nil {
+			return err
+		}
 
-	return cliInstaller.EnablePortalManager(false)
+		return cliInstaller.EnablePortalManager(false)
+	})
 }
 
 func setDisablePortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) error {

--- a/cmd/plugin/cli/enable-portal.go
+++ b/cmd/plugin/cli/enable-portal.go
@@ -6,6 +6,8 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/util/retry"
+
 	apiv1 "github.com/storageos/kubectl-storageos/api/v1"
 	"github.com/storageos/kubectl-storageos/pkg/consts"
 	"github.com/storageos/kubectl-storageos/pkg/installer"
@@ -63,12 +65,14 @@ func enablePortalCmd(config *apiv1.KubectlStorageOSConfig) error {
 		return err
 	}
 
-	cliInstaller, err := installer.NewPortalManagerInstaller(config, false)
-	if err != nil {
-		return err
-	}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		cliInstaller, err := installer.NewPortalManagerInstaller(config, false)
+		if err != nil {
+			return err
+		}
 
-	return cliInstaller.EnablePortalManager(true)
+		return cliInstaller.EnablePortalManager(true)
+	})
 }
 
 func setEnablePortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) error {

--- a/cmd/plugin/cli/uninstall-portal.go
+++ b/cmd/plugin/cli/uninstall-portal.go
@@ -6,6 +6,8 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/client-go/util/retry"
+
 	apiv1 "github.com/storageos/kubectl-storageos/api/v1"
 	"github.com/storageos/kubectl-storageos/pkg/consts"
 	"github.com/storageos/kubectl-storageos/pkg/installer"
@@ -63,16 +65,18 @@ func uninstallPortalCmd(config *apiv1.KubectlStorageOSConfig) error {
 		return err
 	}
 
-	cliInstaller, err := installer.NewPortalManagerInstaller(config, true)
-	if err != nil {
-		return err
-	}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		cliInstaller, err := installer.NewPortalManagerInstaller(config, true)
+		if err != nil {
+			return err
+		}
 
-	if err := cliInstaller.EnablePortalManager(false); err != nil {
-		return err
-	}
+		if err = cliInstaller.EnablePortalManager(false); err != nil {
+			return err
+		}
 
-	return cliInstaller.UninstallPortalManager()
+		return cliInstaller.UninstallPortalManager()
+	})
 }
 
 func setUninstallPortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) error {


### PR DESCRIPTION
Resolves e2e flaking tests like this one:

```
    logger.go:42: 12:21:10 | kubectl-storageos/14-install-portal | secret/storageos-portal-client created
    logger.go:42: 12:21:11 | kubectl-storageos/14-install-portal | configmap/storageos-portal-manager created
    logger.go:42: 12:21:15 | kubectl-storageos/14-install-portal | Error: error when applying patch:
    logger.go:42: 12:21:15 | kubectl-storageos/14-install-portal | {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"storageos.com/v1\",\"kind\":\"StorageOSCluster\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":null,\"finalizers\":[\"storageoscluster-controller\"],\"name\":\"storageoscluster\",\"namespace\":\"storageos\",\"resourceVersion\":\"4285\"},\"spec\":{\"csi\":{},\"enablePortalManager\":true,\"images\":{},\"ingress\":{},\"kvBackend\":{\"address\":\"storageos-etcd.etcd-install-full-tls:2379\"},\"metrics\":{},\"resources\":{},\"secretRefName\":\"storageos-api\",\"service\":{\"name\":\"\",\"type\":\"\"},\"storageClassName\":\"storageos\",\"tlsEtcdSecretRefName\":\"test-secret\",\"tlsEtcdSecretRefNamespace\":\"storageos\"},\"status\":{\"members\":{}}}\n"},"creationTimestamp":null,"resourceVersion":"4285"},"spec":{"enablePortalManager":true}}
    logger.go:42: 12:21:15 | kubectl-storageos/14-install-portal | to:
    logger.go:42: 12:21:15 | kubectl-storageos/14-install-portal | Resource: "storageos.com/v1, Resource=storageosclusters", GroupVersionKind: "storageos.com/v1, Kind=StorageOSCluster"
    logger.go:42: 12:21:15 | kubectl-storageos/14-install-portal | Name: "storageoscluster", Namespace: "storageos"
    logger.go:42: 12:21:15 | kubectl-storageos/14-install-portal | for: "manifestString": Operation cannot be fulfilled on storageosclusters.storageos.com "storageoscluster": the object has been modified; please apply your changes to the latest version and try again
    case.go:361: failed in step 14-install-portal
    case.go:363: exit status 1
```