### PR TITLE
feature/DATA 36 add test cluster flag

### DIFF
--- a/api/v1/kubectlstorageosconfig_types.go
+++ b/api/v1/kubectlstorageosconfig_types.go
@@ -98,6 +98,7 @@ type Install struct {
 	PortalAPIURL                    string `json:"portalAPIURL,omitempty"`
 	LocalPathProvisionerYaml        string `json:"localPathProvisionerYaml,omitempty"`
 	EnableMetrics                   *bool  `json:"enableMetrics,omitempty"`
+	MarkTestCluster                 bool   `json:"markTestCluster,omitempty"`
 }
 
 // Uninstall defines options for cli uninstall subcommand

--- a/cmd/plugin/cli/install.go
+++ b/cmd/plugin/cli/install.go
@@ -85,12 +85,16 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().Bool(installer.IncludeLocalPathProvisionerFlag, false, "install the local path provisioner storage class")
 	cmd.Flags().String(installer.LocalPathProvisionerYamlFlag, "", "local-path-provisioner.yaml path or url")
 	cmd.Flags().Bool(installer.EnableMetricsFlag, false, "enable metrics exporter")
+	cmd.Flags().Bool(installer.HiddenTestCluster, false, "mark the cluster being created as a test cluster")
+	cmd.Flags().MarkHidden(installer.HiddenTestCluster)
 
 	viper.BindPFlags(cmd.Flags())
 
 	return cmd
 }
 
+// TODO: do we need to check since when the operator supports the "isTestClusterFlag"? I assume yes, this will be fun.
+// Need to investigate how the operator works.
 func installCmd(config *apiv1.KubectlStorageOSConfig) error {
 	if config.Spec.Install.StorageOSVersion == "" {
 		config.Spec.Install.StorageOSVersion = version.OperatorLatestSupportedVersion()
@@ -231,6 +235,11 @@ func setInstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) 
 		if err != nil {
 			return err
 		}
+		config.Spec.Install.MarkTestCluster, err = cmd.Flags().GetBool(installer.HiddenTestCluster)
+		if err != nil {
+			return err
+		}
+
 		config.Spec.IncludeLocalPathProvisioner, err = cmd.Flags().GetBool(installer.IncludeLocalPathProvisionerFlag)
 		if err != nil {
 			return err
@@ -310,6 +319,7 @@ func setInstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) 
 	config.Spec.Install.EtcdMemoryLimit = viper.GetString(installer.EtcdMemoryLimitConfig)
 	config.Spec.Install.EtcdReplicas = viper.GetString(installer.EtcdReplicasConfig)
 	config.Spec.Install.EtcdTopologyKey = viper.GetString(installer.EtcdTopologyKeyConfig)
+	config.Spec.Install.MarkTestCluster = viper.GetBool(installer.MarkTestCluster)
 
 	return nil
 }

--- a/cmd/plugin/cli/install.go
+++ b/cmd/plugin/cli/install.go
@@ -85,16 +85,14 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().Bool(installer.IncludeLocalPathProvisionerFlag, false, "install the local path provisioner storage class")
 	cmd.Flags().String(installer.LocalPathProvisionerYamlFlag, "", "local-path-provisioner.yaml path or url")
 	cmd.Flags().Bool(installer.EnableMetricsFlag, false, "enable metrics exporter")
-	cmd.Flags().Bool(installer.HiddenTestCluster, false, "mark the cluster being created as a test cluster")
-	cmd.Flags().MarkHidden(installer.HiddenTestCluster)
+	cmd.Flags().Bool(installer.TestClusterFlag, false, "mark the cluster being created as a test cluster")
+	cmd.Flags().MarkHidden(installer.TestClusterFlag)
 
 	viper.BindPFlags(cmd.Flags())
 
 	return cmd
 }
 
-// TODO: do we need to check since when the operator supports the "isTestClusterFlag"? I assume yes, this will be fun.
-// Need to investigate how the operator works.
 func installCmd(config *apiv1.KubectlStorageOSConfig) error {
 	if config.Spec.Install.StorageOSVersion == "" {
 		config.Spec.Install.StorageOSVersion = version.OperatorLatestSupportedVersion()
@@ -235,7 +233,7 @@ func setInstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) 
 		if err != nil {
 			return err
 		}
-		config.Spec.Install.MarkTestCluster, err = cmd.Flags().GetBool(installer.HiddenTestCluster)
+		config.Spec.Install.MarkTestCluster, err = cmd.Flags().GetBool(installer.TestClusterFlag)
 		if err != nil {
 			return err
 		}
@@ -319,7 +317,7 @@ func setInstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) 
 	config.Spec.Install.EtcdMemoryLimit = viper.GetString(installer.EtcdMemoryLimitConfig)
 	config.Spec.Install.EtcdReplicas = viper.GetString(installer.EtcdReplicasConfig)
 	config.Spec.Install.EtcdTopologyKey = viper.GetString(installer.EtcdTopologyKeyConfig)
-	config.Spec.Install.MarkTestCluster = viper.GetBool(installer.MarkTestCluster)
+	config.Spec.Install.MarkTestCluster = viper.GetBool(installer.TestClusterConfig)
 
 	return nil
 }

--- a/config/crd/bases/storageos.com_kubectlstorageosconfigs.yaml
+++ b/config/crd/bases/storageos.com_kubectlstorageosconfigs.yaml
@@ -95,6 +95,8 @@ spec:
                     type: string
                   localPathProvisionerYaml:
                     type: string
+                  markTestCluster:
+                    type: boolean
                   portalAPIURL:
                     type: string
                   portalClientID:

--- a/config/crd/bases/storageos.com_kubectlstorageosconfigs.yaml
+++ b/config/crd/bases/storageos.com_kubectlstorageosconfigs.yaml
@@ -95,8 +95,6 @@ spec:
                     type: string
                   localPathProvisionerYaml:
                     type: string
-                  markTestCluster:
-                    type: boolean
                   portalAPIURL:
                     type: string
                   portalClientID:

--- a/e2e/tests/dry-run/dry-run-test.sh
+++ b/e2e/tests/dry-run/dry-run-test.sh
@@ -76,4 +76,11 @@ kubectl storageos install "${kargs[@]}" --k8s-version=v1.22.0 --etcd-endpoints=s
 grep --no-filename -A 1 '  metrics:$' "$TMPDIR"/storageos-dry-run/*storageos-cluster.yaml | tail -n 1 | diff <(printf '    enabled: false\n') -
 rm -rf storageos-dry-run
 
+
+# check if the --test-cluster parameter sets the annotation correctly
+kubectl storageos install "${kargs[@]}" --k8s-version=v1.22.0 --etcd-endpoints=storageos.etcd:2379 --test-cluster
+# find the metadata section(s), then select the metadata/annotations one.
+grep --no-filename -A 2 'metadata:$' "$TMPDIR"/storageos-dry-run/*storageos-cluster.yaml |  grep -B 1 -A 1 --no-filename 'annotations:$' | tail -n 1 | diff <(printf '    ondatTestCluster: \"true\"\n') -
+rm -rf storageos-dry-run
+
 echo "Dry run test completed succesfully!"

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -376,7 +376,7 @@ func (in *Installer) installStorageOSCluster() error {
 			Value: "true",
 		}
 
-		if err := in.addPatchesToFSKustomize(filepath.Join(stosDir, clusterDir, stosClusterFile), stosClusterKind, fsStosClusterName, []pluginutils.KustomizePatch{testClusterPatch}); err != nil {
+		if err := in.addPatchesToFSKustomize(filepath.Join(stosDir, clusterDir, kustomizationFile), stosClusterKind, fsStosClusterName, []pluginutils.KustomizePatch{testClusterPatch}); err != nil {
 			return err
 		}
 	}

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -285,6 +285,10 @@ func (in *Installer) installStorageOS() error {
 		return err
 	}
 
+	if in.stosConfig.Spec.Install.MarkTestCluster {
+		fmt.Println("Mark test cluster")
+	}
+
 	if in.installerOptions.resourceQuota {
 		fsResourceQuotaName, err := in.getFieldInFsMultiDocByKind(filepath.Join(stosDir, resourceQuotaDir, resourceQuotaFile), resourceQuotaKind, "metadata", "name")
 		if err != nil {

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -66,6 +66,7 @@ const (
 	EtcdMemoryLimitFlag             = "etcd-memory-limit"
 	EtcdReplicasFlag                = "etcd-replicas"
 	EnableMetricsFlag               = "enable-metrics"
+	HiddenTestCluster               = "test-cluster"
 
 	// config file fields - contain path delimiters for plugin interpretation of config manifest
 	StackTraceConfig                          = "spec.stackTrace"
@@ -119,6 +120,7 @@ const (
 	EtcdMemoryLimitConfig                     = "spec.install.etcdMemoryLimit"
 	EtcdReplicasConfig                        = "spec.install.etcdReplicas"
 	EnableMetricsConfig                       = "spec.install.enableMetrics"
+	MarkTestCluster                           = "spec.install.markTestCluster"
 
 	// dir and file names for in memory fs
 	etcdDir                  = "etcd"

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -66,7 +66,7 @@ const (
 	EtcdMemoryLimitFlag             = "etcd-memory-limit"
 	EtcdReplicasFlag                = "etcd-replicas"
 	EnableMetricsFlag               = "enable-metrics"
-	HiddenTestCluster               = "test-cluster"
+	TestClusterFlag                 = "test-cluster"
 
 	// config file fields - contain path delimiters for plugin interpretation of config manifest
 	StackTraceConfig                          = "spec.stackTrace"
@@ -120,7 +120,7 @@ const (
 	EtcdMemoryLimitConfig                     = "spec.install.etcdMemoryLimit"
 	EtcdReplicasConfig                        = "spec.install.etcdReplicas"
 	EnableMetricsConfig                       = "spec.install.enableMetrics"
-	MarkTestCluster                           = "spec.install.markTestCluster"
+	TestClusterConfig                         = "spec.install.enableTestClusterTaint"
 
 	// dir and file names for in memory fs
 	etcdDir                  = "etcd"


### PR DESCRIPTION
Add a test cluster flag to the plugin that will set a corresponding annotation in the storageos cluster definition. 