### PR TITLE
Cleanup logging

### DIFF
--- a/api/v1/kubectlstorageosconfig_types.go
+++ b/api/v1/kubectlstorageosconfig_types.go
@@ -28,6 +28,7 @@ type KubectlStorageOSConfigSpec struct {
 	SkipStorageOSCluster        bool `json:"skipStorageOSCluster,omitempty"`
 	IncludeEtcd                 bool `json:"includeEtcd,omitempty"`
 	IncludeLocalPathProvisioner bool `json:"includeLocalPathProvisioner,omitempty"`
+	Verbose                     bool `json:"verbose,omitempty"`
 
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file

--- a/cmd/plugin/cli/common.go
+++ b/cmd/plugin/cli/common.go
@@ -18,8 +18,9 @@ import (
 // etcdEndpointsPrompt uses promptui to prompt the user to enter etcd endpoints. The internal validate
 // func is run on each character as it is entered as per the regexp - it does not refer to actual
 // endpoint validation which is handled later.
-func etcdEndpointsPrompt() (string, error) {
-	logger.Printf("   Please enter ETCD endpoints. If more than one endpoint exists, enter endpoints as a comma-delimited list of machine addresses in the cluster.\n\n   Example: 10.42.15.23:2379,10.42.12.22:2379,10.42.13.16:2379\n\n")
+func etcdEndpointsPrompt(log *logger.Logger) (string, error) {
+	log.Prompt("Please enter ETCD endpoints. If more than one endpoint exists, enter endpoints as a comma-delimited list of machine addresses in the cluster.")
+	log.Prompt("Example: 10.42.15.23:2379,10.42.12.22:2379,10.42.13.16:2379")
 	validate := func(input string) error {
 		match, _ := regexp.MatchString("^[a-z0-9,.:-]+$", input)
 		if !match {
@@ -33,12 +34,14 @@ func etcdEndpointsPrompt() (string, error) {
 		Validate: validate,
 	}
 
-	return pluginutils.AskUser(prompt)
+	return pluginutils.AskUser(prompt, log)
 }
 
 // skipNamespaceDeletionPrompt uses promptui to prompt the user to enter decision of skipping namespace deletion
-func skipNamespaceDeletionPrompt() (bool, error) {
-	logger.Printf("   Please confirm namespace deletion.\n   Warning: protected namespaces (default, kube-system, kube-node-lease, kube-public) cannot be deleted by kubectl-storageos.")
+func skipNamespaceDeletionPrompt(log *logger.Logger) (bool, error) {
+	log.Warn("Protected namespaces (default, kube-system, kube-node-lease, kube-public) cannot be deleted by kubectl-storageos.")
+	log.Prompt("Please confirm namespace deletion.")
+
 	yesValues := map[string]bool{
 		"y":   true,
 		"yes": true,
@@ -65,7 +68,7 @@ func skipNamespaceDeletionPrompt() (bool, error) {
 		Validate: validate,
 	}
 
-	input, err := pluginutils.AskUser(prompt)
+	input, err := pluginutils.AskUser(prompt, log)
 	if err != nil {
 		return false, err
 	}
@@ -77,8 +80,8 @@ func skipNamespaceDeletionPrompt() (bool, error) {
 }
 
 // storageClassPrompt uses promptui the user to enter the etcd storage class name
-func storageClassPrompt() (string, error) {
-	logger.Printf("   Please enter the name of the storage class used by the ETCD cluster\n\n")
+func storageClassPrompt(log *logger.Logger) (string, error) {
+	log.Prompt("Please enter the name of the storage class used by the ETCD cluster.")
 	validate := func(input string) error {
 		match, _ := regexp.MatchString("^[a-z0-9.-]+$", input)
 		if !match {
@@ -92,12 +95,12 @@ func storageClassPrompt() (string, error) {
 		Validate: validate,
 	}
 
-	return pluginutils.AskUser(prompt)
+	return pluginutils.AskUser(prompt, log)
 }
 
 // k8sVersionPrompt uses promptui the user to enter the kubernetes version of the target cluster
-func k8sVersionPrompt() (string, error) {
-	logger.Printf("   Please enter the version of the target Kubernetes cluster\n\n")
+func k8sVersionPrompt(log *logger.Logger) (string, error) {
+	log.Prompt("Please enter the version of the target Kubernetes cluster.")
 	validate := func(input string) error {
 		match, _ := regexp.MatchString("v[0-9]+.[0-9]+.[0-9]+", input)
 		if !match {
@@ -111,7 +114,7 @@ func k8sVersionPrompt() (string, error) {
 		Validate: validate,
 	}
 
-	return pluginutils.AskUser(prompt)
+	return pluginutils.AskUser(prompt, log)
 }
 
 func valueOrDefault(value string, def string) string {

--- a/cmd/plugin/cli/disable-portal.go
+++ b/cmd/plugin/cli/disable-portal.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/util/retry"
@@ -11,15 +10,19 @@ import (
 	apiv1 "github.com/storageos/kubectl-storageos/api/v1"
 	"github.com/storageos/kubectl-storageos/pkg/consts"
 	"github.com/storageos/kubectl-storageos/pkg/installer"
+	"github.com/storageos/kubectl-storageos/pkg/logger"
 	pluginutils "github.com/storageos/kubectl-storageos/pkg/utils"
 	"github.com/storageos/kubectl-storageos/pkg/version"
 )
 
+const disablePortal = "disable-portal"
+
 func DisablePortalCmd() *cobra.Command {
 	var err error
 	var traceError bool
+	pluginLogger := logger.NewLogger()
 	cmd := &cobra.Command{
-		Use:          "disable-portal",
+		Use:          disablePortal,
 		Args:         cobra.MinimumNArgs(0),
 		Short:        "Disable StorageOS Portal Manager",
 		Long:         `Disable StorageOS Portal Manager`,
@@ -30,9 +33,6 @@ func DisablePortalCmd() *cobra.Command {
 				err = e
 			})
 
-			v := viper.GetViper()
-			logger.SetQuiet(v.GetBool("quiet"))
-
 			config := &apiv1.KubectlStorageOSConfig{}
 			if err = setDisablePortalValues(cmd, config); err != nil {
 				return
@@ -40,10 +40,15 @@ func DisablePortalCmd() *cobra.Command {
 
 			traceError = config.Spec.StackTrace
 
-			err = disablePortalCmd(config)
+			err = disablePortalCmd(config, pluginLogger)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return pluginutils.HandleError("disable-portal", err, traceError)
+			if err := pluginutils.HandleError(disablePortal, err, traceError); err != nil {
+				pluginLogger.Error(fmt.Sprintf("%s%s", disablePortal, " has failed"))
+				return err
+			}
+			pluginLogger.Success("Portal Manager successfully disabled.")
+			return nil
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
@@ -55,7 +60,7 @@ func DisablePortalCmd() *cobra.Command {
 	return cmd
 }
 
-func disablePortalCmd(config *apiv1.KubectlStorageOSConfig) error {
+func disablePortalCmd(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) error {
 	existingOperatorVersion, err := version.GetExistingOperatorVersion(config.Spec.Install.StorageOSOperatorNamespace)
 	if err != nil {
 		return err
@@ -66,11 +71,12 @@ func disablePortalCmd(config *apiv1.KubectlStorageOSConfig) error {
 	}
 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cliInstaller, err := installer.NewPortalManagerInstaller(config, false)
+		cliInstaller, err := installer.NewPortalManagerInstaller(config, false, log)
 		if err != nil {
 			return err
 		}
 
+		log.Commencing(disablePortal)
 		return cliInstaller.EnablePortalManager(false)
 	})
 }

--- a/cmd/plugin/cli/disable-portal.go
+++ b/cmd/plugin/cli/disable-portal.go
@@ -52,6 +52,7 @@ func DisablePortalCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
+	cmd.Flags().BoolP(installer.VerboseFlag, "v", false, "verbose logging")
 	cmd.Flags().String(installer.StosConfigPathFlag, "", "path to look for kubectl-storageos-config.yaml")
 	cmd.Flags().String(installer.StosOperatorNSFlag, consts.NewOperatorNamespace, "namespace of storageos operator")
 
@@ -61,6 +62,7 @@ func DisablePortalCmd() *cobra.Command {
 }
 
 func disablePortalCmd(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) error {
+	log.Verbose = config.Spec.Verbose
 	existingOperatorVersion, err := version.GetExistingOperatorVersion(config.Spec.Install.StorageOSOperatorNamespace)
 	if err != nil {
 		return err
@@ -98,11 +100,16 @@ func setDisablePortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSCo
 		if err != nil {
 			return err
 		}
+		config.Spec.Verbose, err = cmd.Flags().GetBool(installer.VerboseFlag)
+		if err != nil {
+			return err
+		}
 		config.Spec.Install.StorageOSOperatorNamespace = cmd.Flags().Lookup(installer.StosOperatorNSFlag).Value.String()
 		return nil
 	}
 	// config file read without error, set fields in new config object
 	config.Spec.StackTrace = viper.GetBool(installer.StackTraceConfig)
+	config.Spec.Verbose = viper.GetBool(installer.VerboseConfig)
 	config.Spec.Install.StorageOSOperatorNamespace = viper.GetString(installer.InstallStosOperatorNSConfig)
 	return nil
 }

--- a/cmd/plugin/cli/enable-portal.go
+++ b/cmd/plugin/cli/enable-portal.go
@@ -52,6 +52,7 @@ func EnablePortalCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
+	cmd.Flags().BoolP(installer.VerboseFlag, "v", false, "verbose logging")
 	cmd.Flags().String(installer.StosConfigPathFlag, "", "path to look for kubectl-storageos-config.yaml")
 	cmd.Flags().String(installer.StosOperatorNSFlag, consts.NewOperatorNamespace, "namespace of storageos operator")
 
@@ -61,6 +62,7 @@ func EnablePortalCmd() *cobra.Command {
 }
 
 func enablePortalCmd(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) error {
+	log.Verbose = config.Spec.Verbose
 	existingOperatorVersion, err := version.GetExistingOperatorVersion(config.Spec.Install.StorageOSOperatorNamespace)
 	if err != nil {
 		return err
@@ -97,11 +99,16 @@ func setEnablePortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSCon
 		if err != nil {
 			return err
 		}
+		config.Spec.Verbose, err = cmd.Flags().GetBool(installer.VerboseFlag)
+		if err != nil {
+			return err
+		}
 		config.Spec.Install.StorageOSOperatorNamespace = cmd.Flags().Lookup(installer.StosOperatorNSFlag).Value.String()
 		return nil
 	}
 	// config file read without error, set fields in new config object
 	config.Spec.StackTrace = viper.GetBool(installer.StackTraceConfig)
+	config.Spec.Verbose = viper.GetBool(installer.VerboseConfig)
 	config.Spec.Install.StorageOSOperatorNamespace = viper.GetString(installer.InstallStosOperatorNSConfig)
 	return nil
 }

--- a/cmd/plugin/cli/install-portal.go
+++ b/cmd/plugin/cli/install-portal.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/util/retry"
@@ -11,15 +10,19 @@ import (
 	apiv1 "github.com/storageos/kubectl-storageos/api/v1"
 	"github.com/storageos/kubectl-storageos/pkg/consts"
 	"github.com/storageos/kubectl-storageos/pkg/installer"
+	"github.com/storageos/kubectl-storageos/pkg/logger"
 	pluginutils "github.com/storageos/kubectl-storageos/pkg/utils"
 	"github.com/storageos/kubectl-storageos/pkg/version"
 )
 
+const installPortal = "install-portal"
+
 func InstallPortalCmd() *cobra.Command {
 	var err error
 	var traceError bool
+	pluginLogger := logger.NewLogger()
 	cmd := &cobra.Command{
-		Use:          "install-portal",
+		Use:          installPortal,
 		Args:         cobra.MinimumNArgs(0),
 		Short:        "Install StorageOS Portal Manager",
 		Long:         `Install StorageOS Portal Manager`,
@@ -30,9 +33,6 @@ func InstallPortalCmd() *cobra.Command {
 				err = e
 			})
 
-			v := viper.GetViper()
-			logger.SetQuiet(v.GetBool("quiet"))
-
 			config := &apiv1.KubectlStorageOSConfig{}
 			if err = setInstallPortalValues(cmd, config); err != nil {
 				return
@@ -40,10 +40,15 @@ func InstallPortalCmd() *cobra.Command {
 
 			traceError = config.Spec.StackTrace
 
-			err = installPortalCmd(config)
+			err = installPortalCmd(config, pluginLogger)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return pluginutils.HandleError("install-portal", err, traceError)
+			if err := pluginutils.HandleError(installPortal, err, traceError); err != nil {
+				pluginLogger.Error(fmt.Sprintf("%s%s", installPortal, " has failed"))
+				return err
+			}
+			pluginLogger.Success("Portal Manager installed successfully.")
+			return nil
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
@@ -61,7 +66,7 @@ func InstallPortalCmd() *cobra.Command {
 	return cmd
 }
 
-func installPortalCmd(config *apiv1.KubectlStorageOSConfig) error {
+func installPortalCmd(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) error {
 	existingOperatorVersion, err := version.GetExistingOperatorVersion(config.Spec.Install.StorageOSOperatorNamespace)
 	if err != nil {
 		return err
@@ -80,11 +85,12 @@ func installPortalCmd(config *apiv1.KubectlStorageOSConfig) error {
 	}
 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cliInstaller, err := installer.NewPortalManagerInstaller(config, true)
+		cliInstaller, err := installer.NewPortalManagerInstaller(config, true, log)
 		if err != nil {
 			return err
 		}
 
+		log.Commencing(installPortal)
 		if err := cliInstaller.InstallPortalManager(); err != nil {
 			return err
 		}

--- a/cmd/plugin/cli/install-portal.go
+++ b/cmd/plugin/cli/install-portal.go
@@ -52,6 +52,7 @@ func InstallPortalCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
+	cmd.Flags().BoolP(installer.VerboseFlag, "v", false, "verbose logging")
 	cmd.Flags().String(installer.StosConfigPathFlag, "", "path to look for kubectl-storageos-config.yaml")
 	cmd.Flags().String(installer.StosPortalConfigYamlFlag, "", "storageos-portal-configmap.yaml path or url")
 	cmd.Flags().String(installer.StosPortalClientSecretYamlFlag, "", "storageos-portal-client-secret.yaml path or url")
@@ -67,6 +68,7 @@ func InstallPortalCmd() *cobra.Command {
 }
 
 func installPortalCmd(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) error {
+	log.Verbose = config.Spec.Verbose
 	existingOperatorVersion, err := version.GetExistingOperatorVersion(config.Spec.Install.StorageOSOperatorNamespace)
 	if err != nil {
 		return err
@@ -116,6 +118,10 @@ func setInstallPortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSCo
 		if err != nil {
 			return err
 		}
+		config.Spec.Verbose, err = cmd.Flags().GetBool(installer.VerboseFlag)
+		if err != nil {
+			return err
+		}
 		config.Spec.Install.StorageOSPortalConfigYaml = cmd.Flags().Lookup(installer.StosPortalConfigYamlFlag).Value.String()
 		config.Spec.Install.StorageOSPortalClientSecretYaml = cmd.Flags().Lookup(installer.StosPortalClientSecretYamlFlag).Value.String()
 		config.Spec.Install.StorageOSOperatorNamespace = cmd.Flags().Lookup(installer.StosOperatorNSFlag).Value.String()
@@ -127,6 +133,7 @@ func setInstallPortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSCo
 	}
 	// config file read without error, set fields in new config object
 	config.Spec.StackTrace = viper.GetBool(installer.StackTraceConfig)
+	config.Spec.Verbose = viper.GetBool(installer.VerboseConfig)
 	config.Spec.Install.StorageOSPortalConfigYaml = viper.GetString(installer.InstallStosPortalConfigYamlConfig)
 	config.Spec.Install.StorageOSPortalClientSecretYaml = viper.GetString(installer.InstallStosPortalClientSecretYamlConfig)
 	config.Spec.Install.StorageOSOperatorNamespace = viper.GetString(installer.InstallStosOperatorNSConfig)

--- a/cmd/plugin/cli/install.go
+++ b/cmd/plugin/cli/install.go
@@ -51,6 +51,7 @@ func InstallCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
+	cmd.Flags().BoolP(installer.VerboseFlag, "v", false, "verbose logging")
 	cmd.Flags().Bool(installer.WaitFlag, false, "wait for storageos cluster to enter running phase")
 	cmd.Flags().Bool(installer.DryRunFlag, false, "no installation performed, installation manifests stored locally at \"./storageos-dry-run\"")
 	cmd.Flags().String(installer.StosVersionFlag, "", "version of storageos operator")
@@ -99,6 +100,7 @@ func InstallCmd() *cobra.Command {
 }
 
 func installCmd(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) error {
+	log.Verbose = config.Spec.Verbose
 	if config.Spec.Install.StorageOSVersion == "" {
 		config.Spec.Install.StorageOSVersion = version.OperatorLatestSupportedVersion()
 	}
@@ -208,6 +210,10 @@ func setInstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) 
 		if err != nil {
 			return err
 		}
+		config.Spec.Verbose, err = cmd.Flags().GetBool(installer.VerboseFlag)
+		if err != nil {
+			return err
+		}
 		config.Spec.IncludeEtcd, err = cmd.Flags().GetBool(installer.IncludeEtcdFlag)
 		if err != nil {
 			return err
@@ -285,6 +291,7 @@ func setInstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig) 
 	}
 	// config file read without error, set fields in new config object
 	config.Spec.StackTrace = viper.GetBool(installer.StackTraceConfig)
+	config.Spec.Verbose = viper.GetBool(installer.VerboseConfig)
 	config.Spec.IncludeEtcd = viper.GetBool(installer.IncludeEtcdConfig)
 	config.Spec.SkipStorageOSCluster = viper.GetBool(installer.SkipStosClusterConfig)
 	config.Spec.Install.EnablePortalManager = viper.GetBool(installer.EnablePortalManagerConfig)

--- a/cmd/plugin/cli/uninstall-portal.go
+++ b/cmd/plugin/cli/uninstall-portal.go
@@ -53,6 +53,7 @@ func UninstallPortalCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
+	cmd.Flags().BoolP(installer.VerboseFlag, "v", false, "verbose logging")
 	cmd.Flags().String(installer.StosConfigPathFlag, "", "path to look for kubectl-storageos-config.yaml")
 	cmd.Flags().String(installer.StosOperatorNSFlag, consts.NewOperatorNamespace, "namespace of storageos operator")
 
@@ -62,6 +63,7 @@ func UninstallPortalCmd() *cobra.Command {
 }
 
 func uninstallPortalCmd(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) error {
+	log.Verbose = config.Spec.Verbose
 	existingOperatorVersion, err := version.GetExistingOperatorVersion(config.Spec.Install.StorageOSOperatorNamespace)
 	if err != nil {
 		return err
@@ -103,11 +105,16 @@ func setUninstallPortalValues(cmd *cobra.Command, config *apiv1.KubectlStorageOS
 		if err != nil {
 			return err
 		}
+		config.Spec.Verbose, err = cmd.Flags().GetBool(installer.VerboseFlag)
+		if err != nil {
+			return err
+		}
 		config.Spec.Install.StorageOSOperatorNamespace = cmd.Flags().Lookup(installer.StosOperatorNSFlag).Value.String()
 		return nil
 	}
 	// config file read without error, set fields in new config object
 	config.Spec.StackTrace = viper.GetBool(installer.StackTraceConfig)
+	config.Spec.Verbose = viper.GetBool(installer.VerboseConfig)
 	config.Spec.Install.StorageOSOperatorNamespace = viper.GetString(installer.InstallStosOperatorNSConfig)
 	return nil
 }

--- a/cmd/plugin/cli/uninstall-portal.go
+++ b/cmd/plugin/cli/uninstall-portal.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/util/retry"
@@ -11,15 +10,19 @@ import (
 	apiv1 "github.com/storageos/kubectl-storageos/api/v1"
 	"github.com/storageos/kubectl-storageos/pkg/consts"
 	"github.com/storageos/kubectl-storageos/pkg/installer"
+	"github.com/storageos/kubectl-storageos/pkg/logger"
 	pluginutils "github.com/storageos/kubectl-storageos/pkg/utils"
 	"github.com/storageos/kubectl-storageos/pkg/version"
 )
 
+const uninstallPortal = "uninstall-portal"
+
 func UninstallPortalCmd() *cobra.Command {
 	var err error
 	var traceError bool
+	pluginLogger := logger.NewLogger()
 	cmd := &cobra.Command{
-		Use:          "uninstall-portal",
+		Use:          uninstallPortal,
 		Args:         cobra.MinimumNArgs(0),
 		Short:        "Uninstall StorageOS Portal Manager",
 		Long:         `Uninstall StorageOS Portal Manager`,
@@ -30,9 +33,6 @@ func UninstallPortalCmd() *cobra.Command {
 				err = e
 			})
 
-			v := viper.GetViper()
-			logger.SetQuiet(v.GetBool("quiet"))
-
 			config := &apiv1.KubectlStorageOSConfig{}
 			if err = setUninstallPortalValues(cmd, config); err != nil {
 				return
@@ -40,10 +40,16 @@ func UninstallPortalCmd() *cobra.Command {
 
 			traceError = config.Spec.StackTrace
 
-			err = uninstallPortalCmd(config)
+			err = uninstallPortalCmd(config, pluginLogger)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return pluginutils.HandleError("uninstall-portal", err, traceError)
+			if err := pluginutils.HandleError(uninstallPortal, err, traceError); err != nil {
+				pluginLogger.Error(fmt.Sprintf("%s%s", uninstallPortal, " has failed"))
+
+				return err
+			}
+			pluginLogger.Success("Portal Manager uninstalled successfully.")
+			return nil
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
@@ -55,7 +61,7 @@ func UninstallPortalCmd() *cobra.Command {
 	return cmd
 }
 
-func uninstallPortalCmd(config *apiv1.KubectlStorageOSConfig) error {
+func uninstallPortalCmd(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) error {
 	existingOperatorVersion, err := version.GetExistingOperatorVersion(config.Spec.Install.StorageOSOperatorNamespace)
 	if err != nil {
 		return err
@@ -66,7 +72,7 @@ func uninstallPortalCmd(config *apiv1.KubectlStorageOSConfig) error {
 	}
 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cliInstaller, err := installer.NewPortalManagerInstaller(config, true)
+		cliInstaller, err := installer.NewPortalManagerInstaller(config, true, log)
 		if err != nil {
 			return err
 		}
@@ -75,6 +81,7 @@ func uninstallPortalCmd(config *apiv1.KubectlStorageOSConfig) error {
 			return err
 		}
 
+		log.Commencing(uninstallPortal)
 		return cliInstaller.UninstallPortalManager()
 	})
 }

--- a/cmd/plugin/cli/uninstall.go
+++ b/cmd/plugin/cli/uninstall.go
@@ -51,6 +51,7 @@ func UninstallCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
+	cmd.Flags().BoolP(installer.VerboseFlag, "v", false, "verbose logging")
 	cmd.Flags().Bool(installer.SkipNamespaceDeletionFlag, false, "leaving namespaces untouched")
 	cmd.Flags().Bool(installer.SkipExistingWorkloadCheckFlag, false, "skip check for PVCs using storageos storage class during uninstall")
 	cmd.Flags().Bool(installer.SkipStosClusterFlag, false, "skip storageos cluster uninstallation")
@@ -74,6 +75,7 @@ func UninstallCmd() *cobra.Command {
 }
 
 func uninstallCmd(config *apiv1.KubectlStorageOSConfig, skipNamespaceDeletionHasSet bool, log *logger.Logger) error {
+	log.Verbose = config.Spec.Verbose
 	// if skip namespace delete was not passed via flag or config, prompt user to enter manually
 	if !config.Spec.SkipNamespaceDeletion && !skipNamespaceDeletionHasSet {
 		var err error
@@ -129,6 +131,10 @@ func setUninstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig
 		if err != nil {
 			return err
 		}
+		config.Spec.Verbose, err = cmd.Flags().GetBool(installer.VerboseFlag)
+		if err != nil {
+			return err
+		}
 		config.Spec.SkipNamespaceDeletion, err = cmd.Flags().GetBool(installer.SkipNamespaceDeletionFlag)
 		if err != nil {
 			return err
@@ -165,6 +171,7 @@ func setUninstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSConfig
 	}
 	// config file read without error, set fields in new config object
 	config.Spec.StackTrace = viper.GetBool(installer.StackTraceConfig)
+	config.Spec.Verbose = viper.GetBool(installer.VerboseConfig)
 	config.Spec.SkipNamespaceDeletion = viper.GetBool(installer.SkipNamespaceDeletionConfig)
 	config.Spec.SkipExistingWorkloadCheck = viper.GetBool(installer.SkipExistingWorkloadCheckConfig)
 	config.Spec.SkipStorageOSCluster = viper.GetBool(installer.SkipStosClusterConfig)

--- a/cmd/plugin/cli/upgrade.go
+++ b/cmd/plugin/cli/upgrade.go
@@ -74,6 +74,7 @@ func UpgradeCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool(installer.StackTraceFlag, false, "print stack trace of error")
+	cmd.Flags().BoolP(installer.VerboseFlag, "v", false, "verbose logging")
 	cmd.Flags().Bool(installer.WaitFlag, false, "wait for storageos cluster to enter running phase")
 	cmd.Flags().Bool(installer.SkipExistingWorkloadCheckFlag, false, "skip check for PVCs using storageos storage class during upgrade")
 	cmd.Flags().String(installer.StosVersionFlag, "", "version of storageos operator")
@@ -114,6 +115,7 @@ func UpgradeCmd() *cobra.Command {
 }
 
 func upgradeCmd(uninstallConfig *apiv1.KubectlStorageOSConfig, installConfig *apiv1.KubectlStorageOSConfig, skipNamespaceDeletionHasSet bool, log *logger.Logger) error {
+	log.Verbose = uninstallConfig.Spec.Verbose
 	if installConfig.Spec.Install.StorageOSVersion == "" {
 		installConfig.Spec.Install.StorageOSVersion = version.OperatorLatestSupportedVersion()
 	}
@@ -183,6 +185,10 @@ func setUpgradeInstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSC
 		if err != nil {
 			return err
 		}
+		config.Spec.Verbose, err = cmd.Flags().GetBool(installer.VerboseFlag)
+		if err != nil {
+			return err
+		}
 		config.Spec.Install.Wait, err = cmd.Flags().GetBool(installer.WaitFlag)
 		if err != nil {
 			return err
@@ -232,6 +238,7 @@ func setUpgradeInstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageOSC
 	}
 	// config file read without error, set fields in new config object
 	config.Spec.StackTrace = viper.GetBool(installer.StackTraceConfig)
+	config.Spec.Verbose = viper.GetBool(installer.VerboseConfig)
 	config.Spec.IncludeEtcd = false
 	config.Spec.SkipExistingWorkloadCheck = viper.GetBool(installer.SkipExistingWorkloadCheckConfig)
 	config.Spec.SkipStorageOSCluster = viper.GetBool(installer.SkipStosClusterConfig)
@@ -273,6 +280,10 @@ func setUpgradeUninstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageO
 		}
 
 		// Config file not found; set fields in new config object directly
+		config.Spec.Verbose, err = cmd.Flags().GetBool(installer.VerboseFlag)
+		if err != nil {
+			return err
+		}
 		config.Spec.SkipNamespaceDeletion, err = cmd.Flags().GetBool(installer.SkipNamespaceDeletionFlag)
 		if err != nil {
 			return err
@@ -293,6 +304,7 @@ func setUpgradeUninstallValues(cmd *cobra.Command, config *apiv1.KubectlStorageO
 		return nil
 	}
 	// config file read without error, set fields in new config object
+	config.Spec.Verbose = viper.GetBool(installer.VerboseConfig)
 	config.Spec.SkipNamespaceDeletion = viper.GetBool(installer.SkipNamespaceDeletionConfig)
 	config.Spec.IncludeEtcd = false
 	config.Spec.SkipStorageOSCluster = viper.GetBool(installer.SkipStosClusterConfig)

--- a/cmd/plugin/cli/version.go
+++ b/cmd/plugin/cli/version.go
@@ -1,9 +1,8 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
+	"github.com/storageos/kubectl-storageos/pkg/logger"
 	"github.com/storageos/kubectl-storageos/pkg/version"
 )
 
@@ -15,7 +14,7 @@ func VersionCmd() *cobra.Command {
 		Long:         `Show kubectl storageos version`,
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("%s\n", version.PluginVersion)
+			logger.NewLogger().Infof("%s", version.PluginVersion)
 		},
 	}
 

--- a/pkg/installer/endpoints.go
+++ b/pkg/installer/endpoints.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 	apiv1 "github.com/storageos/kubectl-storageos/api/v1"
-	"github.com/storageos/kubectl-storageos/pkg/logger"
 
 	pluginutils "github.com/storageos/kubectl-storageos/pkg/utils"
 )
@@ -42,9 +41,7 @@ const (
 
 	kubectl storageos is unable to perform ETCD endpoint validation.
 
-	To skip ETCD endpoints validation during installation, set install flag --%s
-
-`
+	To skip ETCD endpoints validation during installation, set install flag --%s`
 
 	errFailedToValidateEndpoint = `
 	Unable to validate ETCD endpoint %s 
@@ -55,18 +52,13 @@ const (
 
 	kubectl storageos is unable to perform ETCD endpoint validation.
 
-	To skip ETCD endpoints validation during installation, set install flag --%s
-	
-`
+	To skip ETCD endpoints validation during installation, set install flag --%s`
 
-	endpointsValidatedMessage = `
-	ETCD endpoint(s) %s successfully validated.
+	endpointsValidatedMessage = `ETCD endpoint(s) %s successfully validated.`
 
-`
 	etcdShellPodDeletionFailMessage = `
 	Failed to cleanup etcd shell pod with error %v, 
-	please delete pod manually after installaion is complete.
-`
+	please delete pod manually after installaion is complete.`
 
 	etcdShellPod = `apiVersion: v1
 kind: Pod
@@ -96,7 +88,7 @@ spec:
       # pod completes and is not restarted after 3m, this is in case
       # the plugin crashes and is unable to delete this pod after health check
       command: [ "sleep" ]
-      args: [ "infinity" ]
+      args: [ "3m" ]
       volumeMounts:
       - mountPath: /run/storageos/pki
         name: etcd-certs
@@ -162,7 +154,7 @@ func (in *Installer) validateEtcd(configSpec apiv1.KubectlStorageOSConfigSpec) e
 	defer func() {
 		if err = in.kubectlClient.Delete(context.TODO(), "", string(etcdShell), true); err != nil {
 			// do nothing, etcd shell pod runs to completion even in unlikely event that delete fails
-			logger.Printf(etcdShellPodDeletionFailMessage, err)
+			in.log.Warnf(etcdShellPodDeletionFailMessage, err)
 		}
 	}()
 
@@ -267,7 +259,7 @@ func (in *Installer) etcdctlHealthCheck(etcdShellPodName, etcdShellPodNS string,
 			return errors.WithStack(fmt.Errorf(stderr))
 		}
 	}
-	logger.Printf(endpointsValidatedMessage, strings.Join(endpoints, ","))
+	in.log.Successf(endpointsValidatedMessage, strings.Join(endpoints, ","))
 
 	return nil
 }

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -58,7 +58,7 @@ func (in *Installer) Install(upgrade bool) error {
 			}
 
 			once.Do(func() {
-				fmt.Printf("waiting for %s to be ready\n", cluster.Name)
+				in.log.Warnf("Waiting for StorageOS cluster '%s' to enter running phase.", cluster.Name)
 			})
 
 			if cluster.Status.Phase != "Running" {

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -9,6 +9,7 @@ import (
 	otkkubectl "github.com/ondat/operator-toolkit/declarative/kubectl"
 	"github.com/pkg/errors"
 	apiv1 "github.com/storageos/kubectl-storageos/api/v1"
+	"github.com/storageos/kubectl-storageos/pkg/logger"
 	pluginutils "github.com/storageos/kubectl-storageos/pkg/utils"
 	pluginversion "github.com/storageos/kubectl-storageos/pkg/version"
 	operatorapi "github.com/storageos/operator/api/v1"
@@ -200,11 +201,12 @@ type Installer struct {
 	installerOptions  *installerOptions
 	dryRunFileCounter int
 	storageOSCluster  *operatorapi.StorageOSCluster
+	log               *logger.Logger
 }
 
 // NewInstaller returns an Installer used for install command
-func NewInstaller(config *apiv1.KubectlStorageOSConfig) (*Installer, error) {
-	in, err := newCommonInstaller(config)
+func NewInstaller(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) (*Installer, error) {
+	in, err := newCommonInstaller(config, log)
 	if err != nil {
 		return in, errors.WithStack(err)
 	}
@@ -232,8 +234,8 @@ func NewInstaller(config *apiv1.KubectlStorageOSConfig) (*Installer, error) {
 }
 
 // NewPortalManagerInstaller returns an Installer used for all portal manager commands
-func NewPortalManagerInstaller(config *apiv1.KubectlStorageOSConfig, manifestsRequired bool) (*Installer, error) {
-	in, err := newCommonInstaller(config)
+func NewPortalManagerInstaller(config *apiv1.KubectlStorageOSConfig, manifestsRequired bool, log *logger.Logger) (*Installer, error) {
+	in, err := newCommonInstaller(config, log)
 	if err != nil {
 		return in, errors.WithStack(err)
 	}
@@ -268,7 +270,7 @@ func NewPortalManagerInstaller(config *apiv1.KubectlStorageOSConfig, manifestsRe
 }
 
 // newCommonInstaller contains logic that is common to NewInstaller and NewPortalManagerInstaller
-func newCommonInstaller(config *apiv1.KubectlStorageOSConfig) (*Installer, error) {
+func newCommonInstaller(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) (*Installer, error) {
 	installer := &Installer{}
 	clientConfig, err := pluginutils.NewClientConfig()
 	if err != nil {
@@ -320,13 +322,14 @@ func newCommonInstaller(config *apiv1.KubectlStorageOSConfig) (*Installer, error
 		kubeClusterID: kubesystemNS.GetUID(),
 		stosConfig:    config,
 		onDiskFileSys: filesys.MakeFsOnDisk(),
+		log:           log,
 	}
 
 	return installer, nil
 }
 
 // NewDryRunInstaller returns a lightweight Installer object for '--dry-run' enabled commands
-func NewDryRunInstaller(config *apiv1.KubectlStorageOSConfig) (*Installer, error) {
+func NewDryRunInstaller(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) (*Installer, error) {
 	installer := &Installer{}
 
 	clientConfig, err := pluginutils.NewClientConfig()
@@ -360,13 +363,14 @@ func NewDryRunInstaller(config *apiv1.KubectlStorageOSConfig) (*Installer, error
 		onDiskFileSys:     filesys.MakeFsOnDisk(),
 		installerOptions:  installerOptions,
 		dryRunFileCounter: 0,
+		log:               log,
 	}
 
 	return installer, nil
 }
 
 // NewUninstaller returns an Installer used for uninstall command
-func NewUninstaller(config *apiv1.KubectlStorageOSConfig) (*Installer, error) {
+func NewUninstaller(config *apiv1.KubectlStorageOSConfig, log *logger.Logger) (*Installer, error) {
 	uninstaller := &Installer{}
 
 	clientConfig, err := pluginutils.NewClientConfig()
@@ -425,6 +429,7 @@ func NewUninstaller(config *apiv1.KubectlStorageOSConfig) (*Installer, error) {
 		onDiskFileSys:    filesys.MakeFsOnDisk(),
 		installerOptions: uninstallerOptions,
 		storageOSCluster: stosCluster,
+		log:              log,
 	}
 
 	return uninstaller, nil

--- a/pkg/installer/uninstall.go
+++ b/pkg/installer/uninstall.go
@@ -511,7 +511,7 @@ func (in *Installer) ensureStorageOSClusterRemoved() error {
 		}
 		return errors.Wrap(errors.WithStack(err), errDuringStosUninstall)
 	}
-	fmt.Println(fmt.Sprintf(removingFinalizersMessage, storageOSCluster.Name))
+	in.log.Warnf(removingFinalizersMessage, storageOSCluster.Name)
 	if err := pluginutils.UpdateStorageOSClusterWithoutFinalizers(in.clientConfig, storageOSCluster); err != nil {
 		return errors.Wrap(errors.WithStack(err), errDuringStosUninstall)
 	}
@@ -542,7 +542,7 @@ func (in *Installer) ensureEtcdClusterRemoved(etcdName string) error {
 		}
 		return errors.Wrap(errors.WithStack(err), errDuringEtcdUninstall)
 	}
-	fmt.Println(fmt.Sprintf(removingFinalizersMessage, etcdCluster.Name))
+	in.log.Warnf(removingFinalizersMessage, etcdCluster.Name)
 	if err := pluginutils.UpdateEtcdClusterWithoutFinalizers(in.clientConfig, etcdCluster); err != nil {
 		return errors.Wrap(errors.WithStack(err), errDuringEtcdUninstall)
 	}

--- a/pkg/installer/utils.go
+++ b/pkg/installer/utils.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 )
 
-const errFlagsNotSet = "The following flags have not been set and are required to perform this command:"
+const errFlagsNotSet = "The following flags have not been set:"
 
 //splitMultiDoc splits a single multidoc manifest into multiple manifests
 func splitMultiDoc(multidoc string) []string {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -11,15 +11,17 @@ import (
 
 // Logger is the cli's logger.Logger implementation
 type Logger struct {
-	writer        io.Writer
+	Writer        io.Writer
 	writerMu      sync.Mutex
 	smartTerminal bool
+	Verbose       bool
 }
 
 func NewLogger() *Logger {
 	return &Logger{
-		writer:        os.Stdout,
+		Writer:        os.Stdout,
 		smartTerminal: IsSmartTerminal(os.Stdout),
+		Verbose:       false,
 	}
 }
 
@@ -28,11 +30,15 @@ func (l *Logger) Prompt(message string) {
 }
 
 func (l *Logger) Info(message string) {
-	l.println(message)
+	if l.Verbose {
+		l.println(message)
+	}
 }
 
 func (l *Logger) Infof(message string, args ...interface{}) {
-	l.println(message, args...)
+	if l.Verbose {
+		l.println(message, args...)
+	}
 }
 
 func (l *Logger) Warn(message string) {
@@ -62,7 +68,7 @@ func (l *Logger) Successf(message string, args ...interface{}) {
 func (l *Logger) println(message string, args ...interface{}) {
 	l.writerMu.Lock()
 	defer l.writerMu.Unlock()
-	fmt.Fprintln(l.writer, fmt.Sprintf(message, args...))
+	fmt.Fprintln(l.Writer, fmt.Sprintf(message, args...))
 }
 
 func (l *Logger) formatPrompt(message string) string {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,19 +2,93 @@ package logger
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/manifoldco/promptui"
 )
 
-var (
-	quiet = false
-)
-
-func SetQuiet(s bool) {
-	quiet = s
+// Logger is the cli's logger.Logger implementation
+type Logger struct {
+	writer        io.Writer
+	writerMu      sync.Mutex
+	smartTerminal bool
 }
 
-func Printf(format string, args ...interface{}) {
-	if quiet {
-		return
+func NewLogger() *Logger {
+	return &Logger{
+		writer:        os.Stdout,
+		smartTerminal: IsSmartTerminal(os.Stdout),
 	}
-	fmt.Printf(format, args...)
+}
+
+func (l *Logger) Prompt(message string) {
+	l.println(l.formatPrompt(message))
+}
+
+func (l *Logger) Info(message string) {
+	l.println(message)
+}
+
+func (l *Logger) Infof(message string, args ...interface{}) {
+	l.println(message, args...)
+}
+
+func (l *Logger) Warn(message string) {
+	l.println(l.formatWithIcon(promptui.IconWarn, message))
+}
+
+func (l *Logger) Warnf(message string, args ...interface{}) {
+	l.println(l.formatWithIcon(promptui.IconWarn, message), args...)
+}
+
+func (l *Logger) Error(message string) {
+	l.println(l.formatWithIcon(promptui.IconBad, message))
+}
+
+func (l *Logger) Errorf(message string, args ...interface{}) {
+	l.println(l.formatWithIcon(promptui.IconBad, message), args...)
+}
+
+func (l *Logger) Success(message string) {
+	l.println(l.formatWithIcon(promptui.IconGood, message))
+}
+
+func (l *Logger) Successf(message string, args ...interface{}) {
+	l.println(l.formatWithIcon(promptui.IconGood, message), args...)
+}
+
+func (l *Logger) println(message string, args ...interface{}) {
+	l.writerMu.Lock()
+	defer l.writerMu.Unlock()
+	fmt.Fprintln(l.writer, fmt.Sprintf(message, args...))
+}
+
+func (l *Logger) formatPrompt(message string) string {
+	if l.smartTerminal {
+		message = promptui.Styler(promptui.FGBold)(message)
+	}
+
+	return fmt.Sprintf("%s%s", message, "\n")
+}
+
+func (l *Logger) formatWithIcon(icon, message string) string {
+	if l.smartTerminal {
+		icon = promptui.Styler(promptui.FGBold)(icon)
+		message = promptui.Styler(promptui.FGBold)(message)
+		message = fmt.Sprintf("%s %s", icon, message)
+	}
+
+	return message
+}
+
+func (l *Logger) Commencing(command string) {
+	commencingMessage := fmt.Sprintf("Commencing %s, this may take a few moments.", command)
+	if l.smartTerminal {
+		timer := ("⏳")
+		commencingMessage = promptui.Styler(promptui.FGBold)(commencingMessage)
+		commencingMessage = fmt.Sprintf("%s%s", timer, commencingMessage)
+	}
+	l.println(commencingMessage)
 }

--- a/pkg/logger/term.go
+++ b/pkg/logger/term.go
@@ -1,0 +1,75 @@
+package logger
+
+import (
+	"io"
+	"os"
+	"runtime"
+
+	"github.com/mattn/go-isatty"
+)
+
+// Code in this file is taken from 'kind' project at:
+// https://github.com/kubernetes-sigs/kind/blob/main/pkg/internal/env/term.go
+
+// IsTerminal returns true if the writer w is a terminal
+func IsTerminal(w io.Writer) bool {
+	if v, ok := (w).(*os.File); ok {
+		return isatty.IsTerminal(v.Fd())
+	}
+	return false
+}
+
+// IsSmartTerminal returns true if the writer w is a terminal AND
+// we think that the terminal is smart enough to use VT escape codes etc.
+func IsSmartTerminal(w io.Writer) bool {
+	return isSmartTerminal(w, runtime.GOOS, os.LookupEnv)
+}
+
+func isSmartTerminal(w io.Writer, GOOS string, lookupEnv func(string) (string, bool)) bool {
+	// Not smart if it's not a tty
+	if !IsTerminal(w) {
+		return false
+	}
+
+	// getenv helper for when we only care about the value
+	getenv := func(e string) string {
+		v, _ := lookupEnv(e)
+		return v
+	}
+
+	// Explicit request for no ANSI escape codes
+	// https://no-color.org/
+	if _, set := lookupEnv("NO_COLOR"); set {
+		return false
+	}
+
+	// Explicitly dumb terminals are not smart
+	// https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals
+	term := getenv("TERM")
+	if term == "dumb" {
+		return false
+	}
+	// st has some bug 🤷‍♂️
+	// https://github.com/kubernetes-sigs/kind/issues/1892
+	if term == "st-256color" {
+		return false
+	}
+
+	// On Windows WT_SESSION is set by the modern terminal component.
+	// Older terminals have poor support for UTF-8, VT escape codes, etc.
+	if GOOS == "windows" && getenv("WT_SESSION") == "" {
+		return false
+	}
+
+	/* CI Systems with bad Fake TTYs */
+	// Travis CI
+	// https://github.com/kubernetes-sigs/kind/issues/1478
+	// We can detect it with documented magical environment variables
+	// https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+	if getenv("HAS_JOSH_K_SEAL_OF_APPROVAL") == "true" && getenv("TRAVIS") == "true" {
+		return false
+	}
+
+	// OK, we'll assume it's smart now, given no evidence otherwise.
+	return true
+}

--- a/pkg/troubleshoot/run.go
+++ b/pkg/troubleshoot/run.go
@@ -37,6 +37,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/supportbundle"
 	"github.com/spf13/viper"
 	"github.com/storageos/kubectl-storageos/pkg/installer"
+	"github.com/storageos/kubectl-storageos/pkg/logger"
 	pluginutils "github.com/storageos/kubectl-storageos/pkg/utils"
 	spin "github.com/tj/go-spin"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -419,7 +420,7 @@ func canTryInsecure(v *viper.Viper) bool {
 		IsConfirm: true,
 	}
 
-	_, err := pluginutils.AskUser(prompt)
+	_, err := pluginutils.AskUser(prompt, logger.NewLogger())
 
 	return err == nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -44,7 +44,7 @@ func HasFlagSet(name string) bool {
 }
 
 // AskUser creates an interactive prompt and waits for user input with timeout
-func AskUser(prompt promptui.Prompt) (string, error) {
+func AskUser(prompt promptui.Prompt, log *logger.Logger) (string, error) {
 	ticker := time.NewTicker(promptTimeout)
 	defer ticker.Stop()
 
@@ -54,7 +54,7 @@ func AskUser(prompt promptui.Prompt) (string, error) {
 	go func() {
 		result, err := prompt.Run()
 		if err != nil {
-			logger.Printf("Prompt failed %s\n", err.Error())
+			log.Errorf("Prompt failed %s", err.Error())
 			errorChan <- err
 		}
 


### PR DESCRIPTION
- Use logger package with standardised messages
- Add verbose flag
- Use 'silent' kubectl when verbose is not set (default)