### PR TITLE
BUG-65 Fix install cluster next to operator not in default namespace

### DIFF
--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -354,7 +354,7 @@ func (in *Installer) installStorageOSCluster() error {
 	var err error
 	// add changes to storageos kustomizations here before kustomizeAndApply calls ie make changes
 	// to storageos/cluster/kustomization.yaml based on flags (or cli in.stosConfig file)
-	if in.stosConfig.Spec.Install.StorageOSClusterNamespace != in.stosConfig.Spec.Install.StorageOSOperatorNamespace {
+	if in.stosConfig.Spec.Install.StorageOSClusterNamespace != consts.NewOperatorNamespace {
 		// apply the provided storageos cluster ns
 		if err = in.kubectlClient.Apply(context.TODO(), "", pluginutils.NamespaceYaml(in.stosConfig.Spec.Install.StorageOSClusterNamespace), true); err != nil {
 			return err


### PR DESCRIPTION
The default namespace for cluster resources is `storageos`. So if someone installs operator and cluster into the same custom-defined namespace, the plugin won't replace namespaces of Custer resources. So with this fix, we compare the target namespace with the namespace in manifests, not the operator target namespace.